### PR TITLE
Set up automated Maven Central publishing with GitHub Actions

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,76 @@
+name: Publish Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g., 1.0.0)'
+        required: true
+        type: string
+
+jobs:
+  publish-release:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+        cache: maven
+        
+    - name: Import GPG key
+      uses: crazy-max/ghaction-import-gpg@v6
+      with:
+        gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+        passphrase: ${{ secrets.GPG_PASSPHRASE }}
+        
+    - name: Configure Maven settings
+      uses: s4u/maven-settings-action@v3.1.0
+      with:
+        servers: |
+          [{
+            "id": "central",
+            "username": "${{ secrets.CENTRAL_USERNAME }}",
+            "password": "${{ secrets.CENTRAL_TOKEN }}"
+          }]
+          
+    - name: Set release version
+      run: |
+        if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          VERSION="${{ github.event.inputs.version }}"
+        else
+          VERSION="${GITHUB_REF#refs/tags/v}"
+        fi
+        echo "RELEASE_VERSION=$VERSION" >> $GITHUB_ENV
+        echo "Release version: $VERSION"
+        
+    - name: Build and test
+      run: ./mvnw clean verify -Drevision=${{ env.RELEASE_VERSION }}
+      
+    - name: Publish release
+      run: ./mvnw deploy -DskipTests -Drevision=${{ env.RELEASE_VERSION }} -Dgpg.skip=false
+      env:
+        GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        
+    - name: Create GitHub Release
+      if: startsWith(github.ref, 'refs/tags/v')
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ env.RELEASE_VERSION }}
+        draft: false
+        prerelease: false
+        body: |
+          ## Changes in version ${{ env.RELEASE_VERSION }}
+          
+          Published to Maven Central: https://central.sonatype.com/artifact/io.tileverse.pmtiles/tileverse-pmtiles-parent/${{ env.RELEASE_VERSION }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,0 +1,47 @@
+name: Publish Snapshot
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  publish-snapshot:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+        cache: maven
+        
+    - name: Import GPG key
+      uses: crazy-max/ghaction-import-gpg@v6
+      with:
+        gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+        passphrase: ${{ secrets.GPG_PASSPHRASE }}
+        
+    - name: Configure Maven settings
+      uses: s4u/maven-settings-action@v3.1.0
+      with:
+        servers: |
+          [{
+            "id": "central",
+            "username": "${{ secrets.CENTRAL_USERNAME }}",
+            "password": "${{ secrets.CENTRAL_TOKEN }}"
+          }]
+          
+    - name: Build and test (manual trigger only)
+      if: ${{ github.event_name == 'workflow_dispatch' }}
+      run: ./mvnw clean verify
+      
+    - name: Publish snapshot
+      if: ${{ !contains(github.event.head_commit.message, '[skip-publish]') }}
+      run: ./mvnw deploy -DskipTests -Dgpg.skip=false
+      env:
+        GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/pom.xml
+++ b/pom.xml
@@ -7,19 +7,63 @@
   <version>${revision}</version>
   <packaging>pom</packaging>
 
-  <name>Tileverse</name>
+  <name>Tileverse PMTiles</name>
   <description>A Java 17 library for reading and writing PMTiles</description>
   <url>https://tileverse.io</url>
+
+  <licenses>
+    <license>
+      <name>Apache License 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Gabriel Roldan</name>
+      <email>gabriel.roldan@gmail.com</email>
+      <organization>Multiversio LLC</organization>
+      <organizationUrl>https://multivers.io</organizationUrl>
+    </developer>
+  </developers>
 
   <modules>
     <module>test-data</module>
     <module>src</module>
   </modules>
 
+  <scm>
+    <connection>scm:git:https://github.com/tileverse-io/tileverse-pmtiles.git</connection>
+    <developerConnection>scm:git:https://github.com/tileverse-io/tileverse-pmtiles.git</developerConnection>
+    <tag>HEAD</tag>
+    <url>https://github.com/tileverse-io/tileverse-pmtiles</url>
+  </scm>
+
+  <issueManagement>
+    <system>GitHub Issues</system>
+    <url>https://github.com/tileverse-io/tileverse-pmtiles/issues</url>
+  </issueManagement>
+
+  <distributionManagement>
+    <repository>
+      <id>central</id>
+      <url>https://central.sonatype.com/api/v1/publisher/deployments/upload</url>
+    </repository>
+    <snapshotRepository>
+      <id>central</id>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+    </snapshotRepository>
+  </distributionManagement>
+
   <properties>
     <!-- CI-friendly version management -->
     <revision>1.0-SNAPSHOT</revision>
     <tileverse-rangereader.version>1.0-SNAPSHOT</tileverse-rangereader.version>
+
+    <!-- Skip GPG signing by default (enabled during publishing) -->
+    <gpg.skip>true</gpg.skip>
+
     <fmt.skip>false</fmt.skip>
     <sortpom.skip>${fmt.skip}</sortpom.skip>
     <sortpom.action>sort</sortpom.action>
@@ -309,6 +353,17 @@
           <artifactId>maven-shade-plugin</artifactId>
           <version>3.5.2</version>
         </plugin>
+        <!-- Central Portal Publishing -->
+        <plugin>
+          <groupId>org.sonatype.central</groupId>
+          <artifactId>central-publishing-maven-plugin</artifactId>
+          <version>0.8.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>3.2.8</version>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -457,6 +512,44 @@
               <goal>clean</goal>
             </goals>
             <phase>clean</phase>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- Central Portal Publishing -->
+      <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <publishingServerId>central</publishingServerId>
+          <deploymentName>Tileverse PMTiles</deploymentName>
+          <autoPublish>true</autoPublish>
+          <waitUntil>published</waitUntil>
+          <excludeArtifacts>
+            <excludeArtifact>tileverse-pmtiles-test-data</excludeArtifact>
+          </excludeArtifacts>
+        </configuration>
+      </plugin>
+
+      <!-- GPG Signing (only when publishing) -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>sign-artifacts</id>
+            <goals>
+              <goal>sign</goal>
+            </goals>
+            <phase>verify</phase>
+            <configuration>
+              <skip>${gpg.skip}</skip>
+              <gpgArguments>
+                <arg>--pinentry-mode</arg>
+                <arg>loopback</arg>
+              </gpgArguments>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
Add complete CI/CD pipeline for publishing to Maven Central via Sonatype Central Portal. Includes snapshot publishing from main branch and release publishing from version tags, with proper GPG signing and authentication.