### PR TITLE
Add PMTiles metadata and TileJSON support

### DIFF
--- a/src/tileverse-pmtiles-reader/src/main/java/io/tileverse/jackson/databind/pmtiles/v3/PMTilesMetadata.java
+++ b/src/tileverse-pmtiles-reader/src/main/java/io/tileverse/jackson/databind/pmtiles/v3/PMTilesMetadata.java
@@ -1,0 +1,222 @@
+/*
+ * (c) Copyright 2025 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.jackson.databind.pmtiles.v3;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.tileverse.jackson.databind.tilejson.v3.TilesetType;
+import io.tileverse.jackson.databind.tilejson.v3.VectorLayer;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Represents PMTiles v3 metadata as defined in the PMTiles specification.
+ * PMTiles metadata is stored as JSON and contains information about the tileset.
+ *
+ * <p>According to the PMTiles v3 specification, metadata MUST contain a valid JSON object
+ * which MAY include additional metadata related to the tileset. For MVT Vector Tiles,
+ * it MUST contain a "vector_layers" key as described in the TileJSON 3.0 specification.
+ *
+ * <p>The PMTiles specification defines specific optional keys: name, description, attribution,
+ * type, and version. Additional properties are allowed and ignored during deserialization
+ * to ensure forward compatibility.
+ *
+ * @since 1.0
+ * @see <a href="https://github.com/protomaps/PMTiles/blob/main/spec/v3/spec.md#5-json-metadata">PMTiles v3 Metadata Specification</a>
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record PMTilesMetadata(
+
+        /**
+         * A name describing the tileset.
+         * Optional field as defined in PMTiles v3 specification.
+         */
+        @JsonProperty("name") String name,
+
+        /**
+         * A text description of the tileset.
+         * Optional field as defined in PMTiles v3 specification.
+         */
+        @JsonProperty("description") String description,
+
+        /**
+         * An attribution to be displayed when the map is shown to a user.
+         * Implementations MAY decide to treat this as HTML or literal text.
+         * Optional field as defined in PMTiles v3 specification.
+         */
+        @JsonProperty("attribution") String attribution,
+
+        /**
+         * The type of the tileset, indicating whether it's a base layer or overlay.
+         * Must be either "baselayer" or "overlay" if present.
+         * Optional field as defined in PMTiles v3 specification.
+         */
+        @JsonProperty("type") TilesetType type,
+
+        /**
+         * The version number of the tileset.
+         * Should be a valid version according to Semantic Versioning 2.0.0.
+         * Optional field as defined in PMTiles v3 specification.
+         */
+        @JsonProperty("version") String version,
+
+        /**
+         * Vector layer definitions for vector tilesets.
+         * Required for MVT Vector Tiles as per TileJSON 3.0 specification.
+         * Each layer describes the data fields and zoom range available.
+         */
+        @JsonProperty("vector_layers") List<VectorLayer> vectorLayers,
+
+        /**
+         * Additional arbitrary metadata as key-value pairs.
+         * This can contain any additional properties not covered by the PMTiles specification.
+         * Allows for future extensions and custom metadata.
+         */
+        @JsonProperty("extras") Map<String, Object> extras) {
+
+    /**
+     * Creates a new PMTilesMetadata with all fields.
+     */
+    public PMTilesMetadata {}
+
+    /**
+     * Creates a minimal PMTilesMetadata with just a name.
+     *
+     * @param name the name of the tileset
+     * @return a new PMTilesMetadata instance
+     */
+    public static PMTilesMetadata of(String name) {
+        return new PMTilesMetadata(name, null, null, null, null, null, null);
+    }
+
+    /**
+     * Creates a PMTilesMetadata with basic tileset information.
+     *
+     * @param name the name of the tileset
+     * @param description the description of the tileset
+     * @param attribution the attribution text
+     * @return a new PMTilesMetadata instance
+     */
+    public static PMTilesMetadata of(String name, String description, String attribution) {
+        return new PMTilesMetadata(name, description, attribution, null, null, null, null);
+    }
+
+    /**
+     * Returns a new PMTilesMetadata with the specified name.
+     *
+     * @param name the new name
+     * @return a new PMTilesMetadata instance
+     */
+    public PMTilesMetadata withName(String name) {
+        return new PMTilesMetadata(name, description, attribution, type, version, vectorLayers, extras);
+    }
+
+    /**
+     * Returns a new PMTilesMetadata with the specified format.
+     *
+     * @param format the new format
+     * @return a new PMTilesMetadata instance
+     */
+
+    /**
+     * Returns a new PMTilesMetadata with the specified description.
+     *
+     * @param description the new description
+     * @return a new PMTilesMetadata instance
+     */
+    public PMTilesMetadata withDescription(String description) {
+        return new PMTilesMetadata(name, description, attribution, type, version, vectorLayers, extras);
+    }
+
+    /**
+     * Returns a new PMTilesMetadata with the specified version.
+     *
+     * @param version the new version
+     * @return a new PMTilesMetadata instance
+     */
+    public PMTilesMetadata withVersion(String version) {
+        return new PMTilesMetadata(name, description, attribution, type, version, vectorLayers, extras);
+    }
+
+    /**
+     * Returns a new PMTilesMetadata with the specified attribution.
+     *
+     * @param attribution the new attribution
+     * @return a new PMTilesMetadata instance
+     */
+    public PMTilesMetadata withAttribution(String attribution) {
+        return new PMTilesMetadata(name, description, attribution, type, version, vectorLayers, extras);
+    }
+
+    /**
+     * Returns a new PMTilesMetadata with the specified center coordinates.
+     *
+     * @param longitude the longitude of the center
+     * @param latitude the latitude of the center
+     * @param zoom the zoom level for the center (optional)
+     * @return a new PMTilesMetadata instance
+     */
+
+    /**
+     * Returns a new PMTilesMetadata with the specified bounds.
+     *
+     * @param west the western longitude
+     * @param south the southern latitude
+     * @param east the eastern longitude
+     * @param north the northern latitude
+     * @return a new PMTilesMetadata instance
+     */
+
+    /**
+     * Returns a new PMTilesMetadata with the specified zoom range.
+     *
+     * @param minZoom the minimum zoom level
+     * @param maxZoom the maximum zoom level
+     * @return a new PMTilesMetadata instance
+     */
+
+    /**
+     * Returns a new PMTilesMetadata with the specified vector layers.
+     *
+     * @param vectorLayers the vector layer definitions
+     * @return a new PMTilesMetadata instance
+     */
+    public PMTilesMetadata withVectorLayers(List<VectorLayer> vectorLayers) {
+        return new PMTilesMetadata(name, description, attribution, type, version, vectorLayers, extras);
+    }
+
+    /**
+     * Returns a new PMTilesMetadata with the specified type.
+     *
+     * @param type the tileset type (baselayer or overlay)
+     * @return a new PMTilesMetadata instance
+     */
+    public PMTilesMetadata withType(TilesetType type) {
+        return new PMTilesMetadata(name, description, attribution, type, version, vectorLayers, extras);
+    }
+
+    /**
+     * Returns a new PMTilesMetadata with the specified extras.
+     *
+     * @param extras additional metadata as key-value pairs
+     * @return a new PMTilesMetadata instance
+     */
+    public PMTilesMetadata withExtras(Map<String, Object> extras) {
+        return new PMTilesMetadata(name, description, attribution, type, version, vectorLayers, extras);
+    }
+}

--- a/src/tileverse-pmtiles-reader/src/main/java/io/tileverse/jackson/databind/pmtiles/v3/package-info.java
+++ b/src/tileverse-pmtiles-reader/src/main/java/io/tileverse/jackson/databind/pmtiles/v3/package-info.java
@@ -1,0 +1,40 @@
+/*
+ * (c) Copyright 2025 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * PMTiles metadata object model with Jackson databind support.
+ *
+ * <p>This package provides a structured representation of PMTiles metadata,
+ * which follows the TileJSON specification format. The metadata contains
+ * information about the tileset including attribution, bounds, vector layers,
+ * and other descriptive properties.
+ *
+ * <p>Key classes:
+ * <ul>
+ * <li>{@link io.tileverse.jackson.databind.pmtiles.v3.PMTilesMetadata} - Main metadata container</li>
+ * </ul>
+ *
+ * <p>This package uses types from {@link io.tileverse.jackson.databind.tilejson.v3} for TileJSON v3.0.0
+ * specification compliance, including {@link io.tileverse.jackson.databind.tilejson.v3.VectorLayer} and
+ * {@link io.tileverse.jackson.databind.tilejson.v3.TilesetType}.
+ *
+ * <p>All classes are designed to work seamlessly with Jackson for JSON
+ * serialization and deserialization, with proper handling of unknown properties
+ * for forward compatibility.
+ *
+ * @since 1.0
+ */
+package io.tileverse.jackson.databind.pmtiles.v3;

--- a/src/tileverse-pmtiles-reader/src/main/java/io/tileverse/jackson/databind/tilejson/v3/TileJSON.java
+++ b/src/tileverse-pmtiles-reader/src/main/java/io/tileverse/jackson/databind/tilejson/v3/TileJSON.java
@@ -1,0 +1,493 @@
+/*
+ * (c) Copyright 2025 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.jackson.databind.tilejson.v3;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/**
+ * Represents a complete TileJSON v3.0.0 specification-compliant metadata object.
+ *
+ * <p>TileJSON is a format for describing map tilesets. It describes tilesets' metadata,
+ * including their bounds, available zoom levels, and vector layer information.
+ *
+ * <p>This implementation strictly follows the TileJSON v3.0.0 schema specification,
+ * including all required and optional fields with proper validation.
+ *
+ * @since 1.0
+ * @see <a href="https://github.com/mapbox/tilejson-spec/tree/master/3.0.0">TileJSON v3.0.0 Specification</a>
+ * @see <a href="https://github.com/mapbox/tilejson-spec/blob/22f5f91e643e8980ef2656674bef84c2869fbe76/3.0.0/schema.json">TileJSON v3.0.0 Schema</a>
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record TileJSON(
+
+        // Required fields per TileJSON v3.0.0 specification
+
+        /**
+         * The TileJSON specification version number.
+         * Must be a semantic version string (e.g., "3.0.0").
+         * Required by TileJSON v3.0.0 specification.
+         */
+        @JsonProperty("tilejson") String tilejson,
+
+        /**
+         * An array of tile endpoints. Each endpoint is a string URL template.
+         * Must contain at least one tile URL.
+         * Required by TileJSON v3.0.0 specification.
+         */
+        @JsonProperty("tiles") List<String> tiles,
+
+        /**
+         * Vector layer definitions for vector tilesets.
+         * Each layer describes the data fields and zoom range available.
+         * Required by TileJSON v3.0.0 specification.
+         */
+        @JsonProperty("vector_layers") List<VectorLayer> vectorLayers,
+
+        // Optional fields per TileJSON v3.0.0 specification
+
+        /**
+         * Attribution text to be displayed when the tileset is shown.
+         * Optional in TileJSON v3.0.0 specification.
+         */
+        @JsonProperty("attribution") String attribution,
+
+        /**
+         * The extent of the tileset in WGS84 coordinates: [west, south, east, north].
+         * Must be an array of exactly 4 numbers if specified.
+         * Optional in TileJSON v3.0.0 specification.
+         */
+        @JsonProperty("bounds") List<Double> bounds,
+
+        /**
+         * The default latitude and longitude of the tileset center.
+         * Must be an array of 2 or 3 numbers [longitude, latitude] or [longitude, latitude, zoom].
+         * Optional in TileJSON v3.0.0 specification.
+         */
+        @JsonProperty("center") List<Double> center,
+
+        /**
+         * A text description of the tileset.
+         * Optional in TileJSON v3.0.0 specification.
+         */
+        @JsonProperty("description") String description,
+
+        /**
+         * The zoom level at which to fill in missing tiles.
+         * Must be between 0 and 30 if specified.
+         * Optional in TileJSON v3.0.0 specification.
+         */
+        @JsonProperty("fillzoom") Integer fillzoom,
+
+        /**
+         * An array of interactivity grid endpoints.
+         * Optional in TileJSON v3.0.0 specification.
+         */
+        @JsonProperty("grids") List<String> grids,
+
+        /**
+         * Legend text to be displayed with the tileset.
+         * Optional in TileJSON v3.0.0 specification.
+         */
+        @JsonProperty("legend") String legend,
+
+        /**
+         * The maximum zoom level supported by the tileset.
+         * Must be between 0 and 30 if specified.
+         * Optional in TileJSON v3.0.0 specification.
+         */
+        @JsonProperty("maxzoom") Integer maxzoom,
+
+        /**
+         * The minimum zoom level supported by the tileset.
+         * Must be between 0 and 30 if specified.
+         * Optional in TileJSON v3.0.0 specification.
+         */
+        @JsonProperty("minzoom") Integer minzoom,
+
+        /**
+         * A name describing the tileset.
+         * Optional in TileJSON v3.0.0 specification.
+         */
+        @JsonProperty("name") String name,
+
+        /**
+         * The tiling scheme. Either "xyz" (default) or "tms".
+         * Optional in TileJSON v3.0.0 specification.
+         */
+        @JsonProperty("scheme") String scheme,
+
+        /**
+         * A mustache template to be used to format interaction data.
+         * Optional in TileJSON v3.0.0 specification.
+         */
+        @JsonProperty("template") String template,
+
+        /**
+         * The version of the tileset.
+         * Should be a semantic version string.
+         * Optional in TileJSON v3.0.0 specification.
+         */
+        @JsonProperty("version") String version) {
+
+    /**
+     * Creates a new TileJSON with all fields.
+     */
+    public TileJSON {}
+
+    /**
+     * Creates a minimal TileJSON with required fields only.
+     *
+     * @param tilejson the TileJSON specification version (required)
+     * @param tiles the tile URL templates (required, must not be empty)
+     * @param vectorLayers the vector layer definitions (required)
+     * @return a new TileJSON instance
+     * @throws IllegalArgumentException if any required field is invalid
+     */
+    public static TileJSON of(String tilejson, List<String> tiles, List<VectorLayer> vectorLayers) {
+        validateRequired(tilejson, tiles, vectorLayers);
+        return new TileJSON(
+                tilejson,
+                tiles,
+                vectorLayers,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null);
+    }
+
+    /**
+     * Creates a TileJSON with common metadata fields.
+     *
+     * @param tilejson the TileJSON specification version (required)
+     * @param tiles the tile URL templates (required, must not be empty)
+     * @param vectorLayers the vector layer definitions (required)
+     * @param name the name of the tileset (optional)
+     * @param description the description of the tileset (optional)
+     * @param attribution the attribution text (optional)
+     * @return a new TileJSON instance
+     * @throws IllegalArgumentException if any required field is invalid
+     */
+    public static TileJSON of(
+            String tilejson,
+            List<String> tiles,
+            List<VectorLayer> vectorLayers,
+            String name,
+            String description,
+            String attribution) {
+        validateRequired(tilejson, tiles, vectorLayers);
+        return new TileJSON(
+                tilejson,
+                tiles,
+                vectorLayers,
+                attribution,
+                null,
+                null,
+                description,
+                null,
+                null,
+                null,
+                null,
+                null,
+                name,
+                null,
+                null,
+                null);
+    }
+
+    /**
+     * Returns a new TileJSON with the specified attribution.
+     *
+     * @param attribution the new attribution
+     * @return a new TileJSON instance
+     */
+    public TileJSON withAttribution(String attribution) {
+        return new TileJSON(
+                tilejson,
+                tiles,
+                vectorLayers,
+                attribution,
+                bounds,
+                center,
+                description,
+                fillzoom,
+                grids,
+                legend,
+                maxzoom,
+                minzoom,
+                name,
+                scheme,
+                template,
+                version);
+    }
+
+    /**
+     * Returns a new TileJSON with the specified bounds.
+     *
+     * @param west the western longitude
+     * @param south the southern latitude
+     * @param east the eastern longitude
+     * @param north the northern latitude
+     * @return a new TileJSON instance
+     * @throws IllegalArgumentException if bounds are invalid
+     */
+    public TileJSON withBounds(double west, double south, double east, double north) {
+        if (west >= east) {
+            throw new IllegalArgumentException("West bound must be less than east bound");
+        }
+        if (south >= north) {
+            throw new IllegalArgumentException("South bound must be less than north bound");
+        }
+        if (west < -180 || east > 180 || south < -90 || north > 90) {
+            throw new IllegalArgumentException("Bounds must be within valid longitude/latitude ranges");
+        }
+        List<Double> boundsCoords = List.of(west, south, east, north);
+        return new TileJSON(
+                tilejson,
+                tiles,
+                vectorLayers,
+                attribution,
+                boundsCoords,
+                center,
+                description,
+                fillzoom,
+                grids,
+                legend,
+                maxzoom,
+                minzoom,
+                name,
+                scheme,
+                template,
+                version);
+    }
+
+    /**
+     * Returns a new TileJSON with the specified center coordinates.
+     *
+     * @param longitude the longitude of the center
+     * @param latitude the latitude of the center
+     * @param zoom the zoom level for the center (optional)
+     * @return a new TileJSON instance
+     * @throws IllegalArgumentException if coordinates are invalid
+     */
+    public TileJSON withCenter(double longitude, double latitude, Double zoom) {
+        if (longitude < -180 || longitude > 180) {
+            throw new IllegalArgumentException("Longitude must be between -180 and 180");
+        }
+        if (latitude < -90 || latitude > 90) {
+            throw new IllegalArgumentException("Latitude must be between -90 and 90");
+        }
+        if (zoom != null && (zoom < 0 || zoom > 30)) {
+            throw new IllegalArgumentException("Zoom level must be between 0 and 30");
+        }
+        List<Double> centerCoords = zoom != null ? List.of(longitude, latitude, zoom) : List.of(longitude, latitude);
+        return new TileJSON(
+                tilejson,
+                tiles,
+                vectorLayers,
+                attribution,
+                bounds,
+                centerCoords,
+                description,
+                fillzoom,
+                grids,
+                legend,
+                maxzoom,
+                minzoom,
+                name,
+                scheme,
+                template,
+                version);
+    }
+
+    /**
+     * Returns a new TileJSON with the specified description.
+     *
+     * @param description the new description
+     * @return a new TileJSON instance
+     */
+    public TileJSON withDescription(String description) {
+        return new TileJSON(
+                tilejson,
+                tiles,
+                vectorLayers,
+                attribution,
+                bounds,
+                center,
+                description,
+                fillzoom,
+                grids,
+                legend,
+                maxzoom,
+                minzoom,
+                name,
+                scheme,
+                template,
+                version);
+    }
+
+    /**
+     * Returns a new TileJSON with the specified zoom range.
+     *
+     * @param minzoom the minimum zoom level (0-30)
+     * @param maxzoom the maximum zoom level (0-30)
+     * @return a new TileJSON instance
+     * @throws IllegalArgumentException if zoom levels are invalid
+     */
+    public TileJSON withZoomRange(Integer minzoom, Integer maxzoom) {
+        validateZoomLevel(minzoom, "minzoom");
+        validateZoomLevel(maxzoom, "maxzoom");
+        if (minzoom != null && maxzoom != null && minzoom > maxzoom) {
+            throw new IllegalArgumentException("minzoom cannot be greater than maxzoom");
+        }
+        return new TileJSON(
+                tilejson,
+                tiles,
+                vectorLayers,
+                attribution,
+                bounds,
+                center,
+                description,
+                fillzoom,
+                grids,
+                legend,
+                maxzoom,
+                minzoom,
+                name,
+                scheme,
+                template,
+                version);
+    }
+
+    /**
+     * Returns a new TileJSON with the specified name.
+     *
+     * @param name the new name
+     * @return a new TileJSON instance
+     */
+    public TileJSON withName(String name) {
+        return new TileJSON(
+                tilejson,
+                tiles,
+                vectorLayers,
+                attribution,
+                bounds,
+                center,
+                description,
+                fillzoom,
+                grids,
+                legend,
+                maxzoom,
+                minzoom,
+                name,
+                scheme,
+                template,
+                version);
+    }
+
+    /**
+     * Returns a new TileJSON with the specified version.
+     *
+     * @param version the new version
+     * @return a new TileJSON instance
+     */
+    public TileJSON withVersion(String version) {
+        return new TileJSON(
+                tilejson,
+                tiles,
+                vectorLayers,
+                attribution,
+                bounds,
+                center,
+                description,
+                fillzoom,
+                grids,
+                legend,
+                maxzoom,
+                minzoom,
+                name,
+                scheme,
+                template,
+                version);
+    }
+
+    /**
+     * Returns a new TileJSON with the specified vector layers.
+     *
+     * @param vectorLayers the vector layer definitions
+     * @return a new TileJSON instance
+     * @throws IllegalArgumentException if vectorLayers is null
+     */
+    public TileJSON withVectorLayers(List<VectorLayer> vectorLayers) {
+        if (vectorLayers == null) {
+            throw new IllegalArgumentException("Vector layers list is required and cannot be null");
+        }
+        return new TileJSON(
+                tilejson,
+                tiles,
+                vectorLayers,
+                attribution,
+                bounds,
+                center,
+                description,
+                fillzoom,
+                grids,
+                legend,
+                maxzoom,
+                minzoom,
+                name,
+                scheme,
+                template,
+                version);
+    }
+
+    private static void validateRequired(String tilejson, List<String> tiles, List<VectorLayer> vectorLayers) {
+        if (tilejson == null || tilejson.isBlank()) {
+            throw new IllegalArgumentException("TileJSON version is required and cannot be null or blank");
+        }
+        if (tiles == null || tiles.isEmpty()) {
+            throw new IllegalArgumentException("Tiles array is required and cannot be null or empty");
+        }
+        if (vectorLayers == null) {
+            throw new IllegalArgumentException("Vector layers list is required and cannot be null");
+        }
+        // Validate each tile URL is not null or blank
+        for (int i = 0; i < tiles.size(); i++) {
+            String tile = tiles.get(i);
+            if (tile == null || tile.isBlank()) {
+                throw new IllegalArgumentException("Tile URL at index " + i + " cannot be null or blank");
+            }
+        }
+    }
+
+    private static void validateZoomLevel(Integer zoom, String fieldName) {
+        if (zoom != null && (zoom < 0 || zoom > 30)) {
+            throw new IllegalArgumentException(fieldName + " must be between 0 and 30, got: " + zoom);
+        }
+    }
+}

--- a/src/tileverse-pmtiles-reader/src/main/java/io/tileverse/jackson/databind/tilejson/v3/TilesetType.java
+++ b/src/tileverse-pmtiles-reader/src/main/java/io/tileverse/jackson/databind/tilejson/v3/TilesetType.java
@@ -1,0 +1,88 @@
+/*
+ * (c) Copyright 2025 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.jackson.databind.tilejson.v3;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Represents the type of a tileset according to the TileJSON v3.0.0 specification.
+ * The type indicates whether the tileset is meant to be used as a base layer
+ * or an overlay layer.
+ *
+ * @since 1.0
+ * @see <a href="https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#32-type">TileJSON Type</a>
+ */
+public enum TilesetType {
+
+    /**
+     * A baselayer tileset provides the foundational map data.
+     * Typically used as the bottom layer in a map stack.
+     */
+    BASELAYER("baselayer"),
+
+    /**
+     * An overlay tileset provides additional data that is rendered
+     * on top of a base layer. Used for thematic data, annotations, etc.
+     */
+    OVERLAY("overlay");
+
+    private final String value;
+
+    TilesetType(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Returns the JSON string value for this tileset type.
+     *
+     * @return the JSON string representation
+     */
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Creates a TilesetType from its JSON string representation.
+     * This method is case-insensitive and handles unknown values gracefully.
+     *
+     * @param value the JSON string value
+     * @return the corresponding TilesetType, or null for unknown values
+     */
+    @JsonCreator
+    public static TilesetType fromValue(String value) {
+        if (value == null) {
+            return null;
+        }
+
+        String normalized = value.toLowerCase().trim();
+        for (TilesetType type : values()) {
+            if (type.value.equals(normalized)) {
+                return type;
+            }
+        }
+
+        // Return null for unknown values to maintain forward compatibility
+        // Jackson will handle this gracefully due to @JsonIgnoreProperties(ignoreUnknown = true)
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/src/tileverse-pmtiles-reader/src/main/java/io/tileverse/jackson/databind/tilejson/v3/VectorLayer.java
+++ b/src/tileverse-pmtiles-reader/src/main/java/io/tileverse/jackson/databind/tilejson/v3/VectorLayer.java
@@ -1,0 +1,187 @@
+/*
+ * (c) Copyright 2025 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.jackson.databind.tilejson.v3;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+
+/**
+ * Represents a vector layer definition within TileJSON v3.0.0 metadata.
+ * Vector layers describe the data fields and zoom range for each layer in a vector tileset.
+ *
+ * <p>This follows the TileJSON v3.0.0 vector layer specification where each vector layer
+ * must have an "id" and "fields" property, with optional "description", "minzoom", and "maxzoom".
+ *
+ * @since 1.0
+ * @see <a href="https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#33-vector_layers">TileJSON Vector Layers</a>
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record VectorLayer(
+
+        /**
+         * The layer identifier used in the vector tiles.
+         * This corresponds to the layer name in the Mapbox Vector Tile format.
+         * Required by TileJSON v3.0.0 specification.
+         */
+        @JsonProperty("id") String id,
+
+        /**
+         * A mapping of field names to their data types.
+         * Common types include "String", "Number", "Boolean".
+         * Field names correspond to properties in the vector tile features.
+         * Required by TileJSON v3.0.0 specification.
+         */
+        @JsonProperty("fields") Map<String, String> fields,
+
+        /**
+         * A human-readable description of the layer.
+         * Optional in TileJSON v3.0.0 specification.
+         */
+        @JsonProperty("description") String description,
+
+        /**
+         * The minimum zoom level at which this layer appears.
+         * Must be between 0 and 30 if specified.
+         * Optional in TileJSON v3.0.0 specification.
+         */
+        @JsonProperty("minzoom") Integer minZoom,
+
+        /**
+         * The maximum zoom level at which this layer appears.
+         * Must be between 0 and 30 if specified.
+         * Optional in TileJSON v3.0.0 specification.
+         */
+        @JsonProperty("maxzoom") Integer maxZoom) {
+
+    /**
+     * Creates a new VectorLayer with all fields.
+     */
+    public VectorLayer {}
+
+    /**
+     * Creates a minimal VectorLayer with required fields only.
+     *
+     * @param id the layer identifier (required)
+     * @param fields the field name to type mapping (required)
+     * @return a new VectorLayer instance
+     * @throws IllegalArgumentException if id is null or blank, or fields is null
+     */
+    public static VectorLayer of(String id, Map<String, String> fields) {
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException("Layer id is required and cannot be null or blank");
+        }
+        if (fields == null) {
+            throw new IllegalArgumentException("Fields map is required and cannot be null");
+        }
+        return new VectorLayer(id, fields, null, null, null);
+    }
+
+    /**
+     * Creates a VectorLayer with basic information.
+     *
+     * @param id the layer identifier (required)
+     * @param fields the field name to type mapping (required)
+     * @param description the layer description (optional)
+     * @return a new VectorLayer instance
+     * @throws IllegalArgumentException if id is null or blank, or fields is null
+     */
+    public static VectorLayer of(String id, Map<String, String> fields, String description) {
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException("Layer id is required and cannot be null or blank");
+        }
+        if (fields == null) {
+            throw new IllegalArgumentException("Fields map is required and cannot be null");
+        }
+        return new VectorLayer(id, fields, description, null, null);
+    }
+
+    /**
+     * Creates a VectorLayer with zoom range information.
+     *
+     * @param id the layer identifier (required)
+     * @param fields the field name to type mapping (required)
+     * @param description the layer description (optional)
+     * @param minZoom the minimum zoom level (optional, must be 0-30)
+     * @param maxZoom the maximum zoom level (optional, must be 0-30)
+     * @return a new VectorLayer instance
+     * @throws IllegalArgumentException if id is null or blank, fields is null, or zoom levels are invalid
+     */
+    public static VectorLayer of(
+            String id, Map<String, String> fields, String description, Integer minZoom, Integer maxZoom) {
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException("Layer id is required and cannot be null or blank");
+        }
+        if (fields == null) {
+            throw new IllegalArgumentException("Fields map is required and cannot be null");
+        }
+        validateZoomLevel(minZoom, "minZoom");
+        validateZoomLevel(maxZoom, "maxZoom");
+        if (minZoom != null && maxZoom != null && minZoom > maxZoom) {
+            throw new IllegalArgumentException("minZoom cannot be greater than maxZoom");
+        }
+        return new VectorLayer(id, fields, description, minZoom, maxZoom);
+    }
+
+    /**
+     * Returns a new VectorLayer with the specified description.
+     *
+     * @param description the new description
+     * @return a new VectorLayer instance
+     */
+    public VectorLayer withDescription(String description) {
+        return new VectorLayer(id, fields, description, minZoom, maxZoom);
+    }
+
+    /**
+     * Returns a new VectorLayer with the specified zoom range.
+     *
+     * @param minZoom the minimum zoom level (0-30)
+     * @param maxZoom the maximum zoom level (0-30)
+     * @return a new VectorLayer instance
+     * @throws IllegalArgumentException if zoom levels are invalid
+     */
+    public VectorLayer withZoomRange(Integer minZoom, Integer maxZoom) {
+        validateZoomLevel(minZoom, "minZoom");
+        validateZoomLevel(maxZoom, "maxZoom");
+        if (minZoom != null && maxZoom != null && minZoom > maxZoom) {
+            throw new IllegalArgumentException("minZoom cannot be greater than maxZoom");
+        }
+        return new VectorLayer(id, fields, description, minZoom, maxZoom);
+    }
+
+    /**
+     * Returns a new VectorLayer with the specified fields.
+     *
+     * @param fields the field name to type mapping
+     * @return a new VectorLayer instance
+     * @throws IllegalArgumentException if fields is null
+     */
+    public VectorLayer withFields(Map<String, String> fields) {
+        if (fields == null) {
+            throw new IllegalArgumentException("Fields map is required and cannot be null");
+        }
+        return new VectorLayer(id, fields, description, minZoom, maxZoom);
+    }
+
+    private static void validateZoomLevel(Integer zoom, String fieldName) {
+        if (zoom != null && (zoom < 0 || zoom > 30)) {
+            throw new IllegalArgumentException(fieldName + " must be between 0 and 30, got: " + zoom);
+        }
+    }
+}

--- a/src/tileverse-pmtiles-reader/src/main/java/io/tileverse/jackson/databind/tilejson/v3/package-info.java
+++ b/src/tileverse-pmtiles-reader/src/main/java/io/tileverse/jackson/databind/tilejson/v3/package-info.java
@@ -1,0 +1,40 @@
+/*
+ * (c) Copyright 2025 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * TileJSON v3.0.0 specification object model with Jackson databind support.
+ *
+ * <p>This package provides a complete implementation of the TileJSON v3.0.0 specification
+ * as defined at <a href="https://github.com/mapbox/tilejson-spec/tree/master/3.0.0">TileJSON 3.0.0 Specification</a>.
+ *
+ * <p>TileJSON is a format for describing map tilesets. It describes tilesets' metadata,
+ * including their bounds, available zoom levels, and vector layer information.
+ *
+ * <p>Key classes:
+ * <ul>
+ * <li>{@link io.tileverse.jackson.databind.tilejson.v3.TileJSON} - Main TileJSON container following v3.0.0 spec</li>
+ * <li>{@link io.tileverse.jackson.databind.tilejson.v3.VectorLayer} - Vector layer definitions with field metadata</li>
+ * <li>{@link io.tileverse.jackson.databind.tilejson.v3.TilesetType} - Enum for tileset type (baselayer/overlay)</li>
+ * </ul>
+ *
+ * <p>All classes are designed to work seamlessly with Jackson for JSON
+ * serialization and deserialization, with strict adherence to the TileJSON v3.0.0 schema
+ * while supporting unknown properties for forward compatibility.
+ *
+ * @since 1.0
+ * @see <a href="https://github.com/mapbox/tilejson-spec/tree/master/3.0.0">TileJSON v3.0.0 Specification</a>
+ */
+package io.tileverse.jackson.databind.tilejson.v3;

--- a/src/tileverse-pmtiles-reader/src/main/java/io/tileverse/pmtiles/PMTilesHeader.java
+++ b/src/tileverse-pmtiles-reader/src/main/java/io/tileverse/pmtiles/PMTilesHeader.java
@@ -25,6 +25,31 @@ import java.util.Arrays;
 /**
  * Represents the header of a PMTiles file, based on version 3 of the PMTiles specification.
  * The header is a fixed-length structure of 127 bytes containing metadata and offsets.
+ *
+ * @param rootDirOffset the byte offset from the start of the archive to the first byte of the root directory
+ * @param rootDirBytes the number of bytes in the root directory
+ * @param jsonMetadataOffset the byte offset from the start of the archive to the first byte of the JSON metadata
+ * @param jsonMetadataBytes the number of bytes of JSON metadata
+ * @param leafDirsOffset the byte offset from the start of the archive to the first byte of leaf directories
+ * @param leafDirsBytes the total number of bytes of leaf directories
+ * @param tileDataOffset the byte offset from the start of the archive to the first byte of tile data
+ * @param tileDataBytes the total number of bytes of tile data
+ * @param addressedTilesCount the total number of tiles before Run Length Encoding, or 0 if unknown
+ * @param tileEntriesCount the total number of tile entries where RunLength > 0, or 0 if unknown
+ * @param tileContentsCount the total number of blobs in the tile data section, or 0 if unknown
+ * @param clustered whether the tiles in the tile data section are ordered by TileID
+ * @param internalCompression the compression type used for directories and metadata (see COMPRESSION_* constants)
+ * @param tileCompression the compression type used for individual tiles (see COMPRESSION_* constants)
+ * @param tileType the type of tiles stored in this archive (see TILETYPE_* constants)
+ * @param minZoom the minimum zoom level of tiles in this archive (0-30)
+ * @param maxZoom the maximum zoom level of tiles in this archive (0-30, must be >= minZoom)
+ * @param minLonE7 the minimum longitude of the bounding box in E7 format (longitude * 10,000,000)
+ * @param minLatE7 the minimum latitude of the bounding box in E7 format (latitude * 10,000,000)
+ * @param maxLonE7 the maximum longitude of the bounding box in E7 format (longitude * 10,000,000)
+ * @param maxLatE7 the maximum latitude of the bounding box in E7 format (latitude * 10,000,000)
+ * @param centerZoom the initial recommended zoom level for displaying the tileset
+ * @param centerLonE7 the center longitude for displaying the tileset in E7 format (longitude * 10,000,000)
+ * @param centerLatE7 the center latitude for displaying the tileset in E7 format (latitude * 10,000,000)
  */
 public record PMTilesHeader(
         long rootDirOffset,
@@ -77,6 +102,54 @@ public record PMTilesHeader(
      */
     public byte version() {
         return VERSION;
+    }
+
+    /**
+     * Returns the minimum longitude as a double value.
+     * @return The minimum longitude in decimal degrees
+     */
+    public double minLon() {
+        return minLonE7 / 10_000_000.0;
+    }
+
+    /**
+     * Returns the minimum latitude as a double value.
+     * @return The minimum latitude in decimal degrees
+     */
+    public double minLat() {
+        return minLatE7 / 10_000_000.0;
+    }
+
+    /**
+     * Returns the maximum longitude as a double value.
+     * @return The maximum longitude in decimal degrees
+     */
+    public double maxLon() {
+        return maxLonE7 / 10_000_000.0;
+    }
+
+    /**
+     * Returns the maximum latitude as a double value.
+     * @return The maximum latitude in decimal degrees
+     */
+    public double maxLat() {
+        return maxLatE7 / 10_000_000.0;
+    }
+
+    /**
+     * Returns the center longitude as a double value.
+     * @return The center longitude in decimal degrees
+     */
+    public double centerLon() {
+        return centerLonE7 / 10_000_000.0;
+    }
+
+    /**
+     * Returns the center latitude as a double value.
+     * @return The center latitude in decimal degrees
+     */
+    public double centerLat() {
+        return centerLatE7 / 10_000_000.0;
     }
 
     /**

--- a/src/tileverse-pmtiles-reader/src/test/java/io/tileverse/jackson/databind/pmtiles/v3/PMTilesMetadataTest.java
+++ b/src/tileverse-pmtiles-reader/src/test/java/io/tileverse/jackson/databind/pmtiles/v3/PMTilesMetadataTest.java
@@ -1,0 +1,346 @@
+/*
+ * (c) Copyright 2025 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.jackson.databind.pmtiles.v3;
+
+import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.tileverse.jackson.databind.tilejson.v3.TilesetType;
+import io.tileverse.jackson.databind.tilejson.v3.VectorLayer;
+import io.tileverse.pmtiles.PMTilesReader;
+import io.tileverse.rangereader.RangeReader;
+import io.tileverse.rangereader.file.FileRangeReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for PMTiles metadata object model following PMTiles v3 specification.
+ */
+class PMTilesMetadataTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    protected static Path andorraPmTiles;
+
+    @BeforeAll
+    static void copyTestData(@TempDir Path tmpFolder) throws IOException {
+        try (InputStream in = requireNonNull(PMTilesMetadataTest.class.getResourceAsStream("/andorra.pmtiles"))) {
+            andorraPmTiles = tmpFolder.resolve("andorra.pmtiles");
+            Files.copy(in, andorraPmTiles);
+        }
+    }
+
+    @Test
+    void testSimpleMetadataDeserialization() throws Exception {
+        String json =
+                """
+            {
+                "name": "Test Tileset",
+                "description": "A test tileset for unit testing",
+                "version": "1.0.0",
+                "attribution": "© Test Contributors",
+                "type": "baselayer"
+            }
+            """;
+
+        PMTilesMetadata metadata = objectMapper.readValue(json, PMTilesMetadata.class);
+
+        assertEquals("Test Tileset", metadata.name());
+        assertEquals("A test tileset for unit testing", metadata.description());
+        assertEquals("1.0.0", metadata.version());
+        assertEquals("© Test Contributors", metadata.attribution());
+        assertEquals(TilesetType.BASELAYER, metadata.type());
+        assertNull(metadata.vectorLayers());
+        assertNull(metadata.extras());
+    }
+
+    @Test
+    void testVectorTilesetMetadata() throws Exception {
+        String json =
+                """
+            {
+                "name": "Vector Tileset",
+                "description": "A vector tileset with layers",
+                "version": "2.0.0",
+                "attribution": "© OpenStreetMap contributors",
+                "type": "overlay",
+                "vector_layers": [
+                    {
+                        "id": "buildings",
+                        "description": "Building footprints",
+                        "minzoom": 10,
+                        "maxzoom": 18,
+                        "fields": {
+                            "height": "Number",
+                            "name": "String",
+                            "type": "String"
+                        }
+                    },
+                    {
+                        "id": "roads",
+                        "description": "Road network",
+                        "minzoom": 0,
+                        "maxzoom": 18,
+                        "fields": {
+                            "name": "String",
+                            "highway": "String",
+                            "oneway": "Boolean"
+                        }
+                    }
+                ]
+            }
+            """;
+
+        PMTilesMetadata metadata = objectMapper.readValue(json, PMTilesMetadata.class);
+
+        assertEquals("Vector Tileset", metadata.name());
+        assertEquals("A vector tileset with layers", metadata.description());
+        assertEquals("2.0.0", metadata.version());
+        assertEquals("© OpenStreetMap contributors", metadata.attribution());
+        assertEquals(TilesetType.OVERLAY, metadata.type());
+
+        // Test vector layers (required for MVT tilesets)
+        assertNotNull(metadata.vectorLayers());
+        assertEquals(2, metadata.vectorLayers().size());
+
+        VectorLayer buildings = metadata.vectorLayers().get(0);
+        assertEquals("buildings", buildings.id());
+        assertEquals("Building footprints", buildings.description());
+        assertEquals(Integer.valueOf(10), buildings.minZoom());
+        assertEquals(Integer.valueOf(18), buildings.maxZoom());
+        assertNotNull(buildings.fields());
+        assertEquals("Number", buildings.fields().get("height"));
+        assertEquals("String", buildings.fields().get("name"));
+        assertEquals("String", buildings.fields().get("type"));
+
+        VectorLayer roads = metadata.vectorLayers().get(1);
+        assertEquals("roads", roads.id());
+        assertEquals("Road network", roads.description());
+        assertEquals(Integer.valueOf(0), roads.minZoom());
+        assertEquals(Integer.valueOf(18), roads.maxZoom());
+        assertNotNull(roads.fields());
+        assertEquals("String", roads.fields().get("name"));
+        assertEquals("String", roads.fields().get("highway"));
+        assertEquals("Boolean", roads.fields().get("oneway"));
+    }
+
+    @Test
+    void testMetadataWithUnknownProperties() throws Exception {
+        String json =
+                """
+            {
+                "name": "Test Tileset",
+                "description": "Test description",
+                "type": "baselayer",
+                "unknown_property": "should be ignored",
+                "custom_field": {
+                    "nested": "value"
+                },
+                "bounds": [-180, -85, 180, 85],
+                "center": [0, 0, 5],
+                "minzoom": 0,
+                "maxzoom": 14
+            }
+            """;
+
+        // Should not throw an exception due to unknown properties
+        PMTilesMetadata metadata = objectMapper.readValue(json, PMTilesMetadata.class);
+
+        assertEquals("Test Tileset", metadata.name());
+        assertEquals("Test description", metadata.description());
+        assertEquals(TilesetType.BASELAYER, metadata.type());
+        // Unknown properties are ignored, but doesn't cause deserialization to fail
+    }
+
+    @Test
+    void testMetadataSerialization() throws Exception {
+        PMTilesMetadata original = PMTilesMetadata.of("Test Tileset", "Test description", "© Test")
+                .withVersion("1.0.0")
+                .withType(TilesetType.BASELAYER)
+                .withVectorLayers(List.of(VectorLayer.of("test", Map.of("name", "String"), "Test layer")
+                        .withZoomRange(0, 14)));
+
+        // Serialize to JSON
+        String json = objectMapper.writeValueAsString(original);
+        assertNotNull(json);
+        assertTrue(json.contains("Test Tileset"));
+        assertTrue(json.contains("baselayer"));
+
+        // Deserialize back
+        PMTilesMetadata deserialized = objectMapper.readValue(json, PMTilesMetadata.class);
+
+        assertEquals(original.name(), deserialized.name());
+        assertEquals(original.description(), deserialized.description());
+        assertEquals(original.version(), deserialized.version());
+        assertEquals(original.attribution(), deserialized.attribution());
+        assertEquals(original.type(), deserialized.type());
+
+        // Check vector layer
+        assertNotNull(deserialized.vectorLayers());
+        assertEquals(1, deserialized.vectorLayers().size());
+        VectorLayer layer = deserialized.vectorLayers().get(0);
+        assertEquals("test", layer.id());
+        assertEquals("Test layer", layer.description());
+    }
+
+    @Test
+    void testTilesetTypeEnum() throws Exception {
+        // Test baselayer type
+        String baselayerJson =
+                """
+            {
+                "name": "Base Map",
+                "type": "baselayer"
+            }
+            """;
+
+        PMTilesMetadata baselayerMetadata = objectMapper.readValue(baselayerJson, PMTilesMetadata.class);
+        assertEquals(TilesetType.BASELAYER, baselayerMetadata.type());
+
+        // Test overlay type
+        String overlayJson =
+                """
+            {
+                "name": "Overlay Map",
+                "type": "overlay"
+            }
+            """;
+
+        PMTilesMetadata overlayMetadata = objectMapper.readValue(overlayJson, PMTilesMetadata.class);
+        assertEquals(TilesetType.OVERLAY, overlayMetadata.type());
+
+        // Test unknown type (should be null for forward compatibility)
+        String unknownJson =
+                """
+            {
+                "name": "Unknown Map",
+                "type": "unknown_type"
+            }
+            """;
+
+        PMTilesMetadata unknownMetadata = objectMapper.readValue(unknownJson, PMTilesMetadata.class);
+        assertNull(unknownMetadata.type());
+
+        // Test serialization
+        PMTilesMetadata original = PMTilesMetadata.of("Test").withType(TilesetType.BASELAYER);
+        String json = objectMapper.writeValueAsString(original);
+        assertTrue(json.contains("\"type\":\"baselayer\""));
+
+        PMTilesMetadata deserialized = objectMapper.readValue(json, PMTilesMetadata.class);
+        assertEquals(TilesetType.BASELAYER, deserialized.type());
+    }
+
+    @Test
+    void testBuilderMethods() {
+        PMTilesMetadata metadata = PMTilesMetadata.of("Original Name")
+                .withDescription("Test description")
+                .withVersion("1.0")
+                .withAttribution("© Test")
+                .withType(TilesetType.OVERLAY);
+
+        assertEquals("Original Name", metadata.name());
+        assertEquals("Test description", metadata.description());
+        assertEquals("1.0", metadata.version());
+        assertEquals("© Test", metadata.attribution());
+        assertEquals(TilesetType.OVERLAY, metadata.type());
+    }
+
+    @Test
+    void testVectorLayerBuilderMethods() {
+        VectorLayer layer = VectorLayer.of("test", Map.of("name", "String", "count", "Number"))
+                .withDescription("Test layer")
+                .withZoomRange(0, 10);
+
+        assertEquals("test", layer.id());
+        assertEquals("Test layer", layer.description());
+        assertEquals(Integer.valueOf(0), layer.minZoom());
+        assertEquals(Integer.valueOf(10), layer.maxZoom());
+        assertNotNull(layer.fields());
+        assertEquals("String", layer.fields().get("name"));
+        assertEquals("Number", layer.fields().get("count"));
+    }
+
+    @Test
+    void testEmptyMetadata() {
+        PMTilesMetadata empty = PMTilesMetadata.of(null);
+        assertNull(empty.name());
+        assertNull(empty.description());
+        assertNull(empty.version());
+        assertNull(empty.attribution());
+        assertNull(empty.vectorLayers());
+        assertNull(empty.type());
+        assertNull(empty.extras());
+    }
+
+    @Test
+    void testAndorraMetadata() throws Exception {
+        // Use the same test file as PMTilesReaderTest
+        try (RangeReader rangeReader = FileRangeReader.of(andorraPmTiles);
+                PMTilesReader pmtilesReader = new PMTilesReader(rangeReader)) {
+
+            PMTilesMetadata metadata = pmtilesReader.getMetadataObject();
+            assertNotNull(metadata);
+
+            // Verify basic metadata fields that should be present per PMTiles spec
+            assertEquals("Shortbread", metadata.name());
+            assertEquals(
+                    "A basic, lean, general-purpose vector tile schema for OpenStreetMap data. See https://shortbread.geofabrik.de/",
+                    metadata.description());
+            assertEquals(
+                    "<a href=\"https://www.openstreetmap.org/copyright\" target=\"_blank\">&copy; OpenStreetMap contributors</a>",
+                    metadata.attribution());
+
+            // Verify type
+            assertEquals(TilesetType.BASELAYER, metadata.type());
+
+            // Verify vector layers (required for MVT tilesets)
+            assertNotNull(metadata.vectorLayers());
+            assertEquals(21, metadata.vectorLayers().size());
+
+            // Check specific vector layers from the pmtiles show output
+            Map<String, VectorLayer> layerMap =
+                    metadata.vectorLayers().stream().collect(Collectors.toMap(VectorLayer::id, Function.identity()));
+
+            // Verify some key layers exist
+            assertTrue(layerMap.containsKey("addresses"), "Should have addresses layer");
+            assertTrue(layerMap.containsKey("boundaries"), "Should have boundaries layer");
+            assertTrue(layerMap.containsKey("buildings"), "Should have buildings layer");
+            assertTrue(layerMap.containsKey("streets"), "Should have streets layer");
+
+            // Verify a specific layer's structure
+            VectorLayer addresses = layerMap.get("addresses");
+            assertNotNull(addresses, "addresses layer should exist");
+            assertEquals(Integer.valueOf(14), addresses.minZoom());
+            assertEquals(Integer.valueOf(14), addresses.maxZoom());
+            assertNotNull(addresses.fields());
+            assertEquals("String", addresses.fields().get("housename"));
+            assertEquals("String", addresses.fields().get("housenumber"));
+        }
+    }
+}

--- a/src/tileverse-pmtiles-reader/src/test/java/io/tileverse/jackson/databind/tilejson/v3/TileJSONTest.java
+++ b/src/tileverse-pmtiles-reader/src/test/java/io/tileverse/jackson/databind/tilejson/v3/TileJSONTest.java
@@ -1,0 +1,313 @@
+/*
+ * (c) Copyright 2025 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.jackson.databind.tilejson.v3;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for TileJSON v3.0.0 specification compliance.
+ */
+class TileJSONTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void testMinimalTileJSON() throws Exception {
+        // Create minimal valid TileJSON
+        VectorLayer layer = VectorLayer.of("test", Map.of("name", "string"));
+        TileJSON tileJSON = TileJSON.of("3.0.0", List.of("https://example.com/{z}/{x}/{y}.pbf"), List.of(layer));
+
+        assertEquals("3.0.0", tileJSON.tilejson());
+        assertEquals(1, tileJSON.tiles().size());
+        assertEquals("https://example.com/{z}/{x}/{y}.pbf", tileJSON.tiles().get(0));
+        assertEquals(1, tileJSON.vectorLayers().size());
+        assertEquals("test", tileJSON.vectorLayers().get(0).id());
+
+        // Test serialization
+        String json = objectMapper.writeValueAsString(tileJSON);
+        assertTrue(json.contains("\"tilejson\":\"3.0.0\""));
+        assertTrue(json.contains("\"tiles\":[\"https://example.com/{z}/{x}/{y}.pbf\"]"));
+        assertTrue(json.contains("\"vector_layers\""));
+
+        // Test deserialization
+        TileJSON deserialized = objectMapper.readValue(json, TileJSON.class);
+        assertEquals(tileJSON.tilejson(), deserialized.tilejson());
+        assertEquals(tileJSON.tiles(), deserialized.tiles());
+        assertEquals(
+                tileJSON.vectorLayers().get(0).id(),
+                deserialized.vectorLayers().get(0).id());
+    }
+
+    @Test
+    void testCompleteTileJSON() throws Exception {
+        VectorLayer buildings = VectorLayer.of(
+                        "buildings", Map.of("height", "Number", "type", "String"), "Building footprints")
+                .withZoomRange(12, 18);
+        VectorLayer roads = VectorLayer.of("roads", Map.of("name", "String", "highway", "String"), "Road network")
+                .withZoomRange(6, 18);
+
+        TileJSON tileJSON = TileJSON.of(
+                        "3.0.0",
+                        List.of(
+                                "https://tile1.example.com/{z}/{x}/{y}.pbf",
+                                "https://tile2.example.com/{z}/{x}/{y}.pbf"),
+                        List.of(buildings, roads),
+                        "Test Tileset",
+                        "A comprehensive test tileset",
+                        "© Test Contributors")
+                .withBounds(-180, -85, 180, 85)
+                .withCenter(-74.0059, 40.7128, 10.0)
+                .withZoomRange(0, 18)
+                .withVersion("1.0.0");
+
+        // Verify all fields
+        assertEquals("3.0.0", tileJSON.tilejson());
+        assertEquals("Test Tileset", tileJSON.name());
+        assertEquals("A comprehensive test tileset", tileJSON.description());
+        assertEquals("© Test Contributors", tileJSON.attribution());
+        assertEquals("1.0.0", tileJSON.version());
+
+        assertEquals(2, tileJSON.tiles().size());
+        assertEquals(
+                "https://tile1.example.com/{z}/{x}/{y}.pbf", tileJSON.tiles().get(0));
+        assertEquals(
+                "https://tile2.example.com/{z}/{x}/{y}.pbf", tileJSON.tiles().get(1));
+
+        assertEquals(4, tileJSON.bounds().size());
+        assertEquals(-180.0, tileJSON.bounds().get(0));
+        assertEquals(-85.0, tileJSON.bounds().get(1));
+        assertEquals(180.0, tileJSON.bounds().get(2));
+        assertEquals(85.0, tileJSON.bounds().get(3));
+
+        assertEquals(3, tileJSON.center().size());
+        assertEquals(-74.0059, tileJSON.center().get(0));
+        assertEquals(40.7128, tileJSON.center().get(1));
+        assertEquals(10.0, tileJSON.center().get(2));
+
+        assertEquals(Integer.valueOf(0), tileJSON.minzoom());
+        assertEquals(Integer.valueOf(18), tileJSON.maxzoom());
+
+        assertEquals(2, tileJSON.vectorLayers().size());
+        assertEquals("buildings", tileJSON.vectorLayers().get(0).id());
+        assertEquals("roads", tileJSON.vectorLayers().get(1).id());
+
+        // Test serialization/deserialization
+        String json = objectMapper.writeValueAsString(tileJSON);
+        TileJSON deserialized = objectMapper.readValue(json, TileJSON.class);
+
+        assertEquals(tileJSON.tilejson(), deserialized.tilejson());
+        assertEquals(tileJSON.name(), deserialized.name());
+        assertEquals(tileJSON.description(), deserialized.description());
+        assertEquals(tileJSON.attribution(), deserialized.attribution());
+        assertEquals(tileJSON.bounds(), deserialized.bounds());
+        assertEquals(tileJSON.center(), deserialized.center());
+        assertEquals(tileJSON.minzoom(), deserialized.minzoom());
+        assertEquals(tileJSON.maxzoom(), deserialized.maxzoom());
+        assertEquals(tileJSON.vectorLayers().size(), deserialized.vectorLayers().size());
+    }
+
+    @Test
+    void testRequiredFieldValidation() {
+        VectorLayer layer = VectorLayer.of("test", Map.of("name", "string"));
+
+        // Test null tilejson
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> TileJSON.of(null, List.of("https://example.com/{z}/{x}/{y}.pbf"), List.of(layer)));
+
+        // Test blank tilejson
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> TileJSON.of("", List.of("https://example.com/{z}/{x}/{y}.pbf"), List.of(layer)));
+
+        // Test null tiles
+        assertThrows(IllegalArgumentException.class, () -> TileJSON.of("3.0.0", null, List.of(layer)));
+
+        // Test empty tiles
+        assertThrows(IllegalArgumentException.class, () -> TileJSON.of("3.0.0", List.of(), List.of(layer)));
+
+        // Test null tile URL
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> TileJSON.of("3.0.0", java.util.Arrays.asList((String) null), List.of(layer)));
+
+        // Test blank tile URL
+        assertThrows(IllegalArgumentException.class, () -> TileJSON.of("3.0.0", List.of(""), List.of(layer)));
+
+        // Test null vector layers
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> TileJSON.of("3.0.0", List.of("https://example.com/{z}/{x}/{y}.pbf"), null));
+    }
+
+    @Test
+    void testBoundsValidation() {
+        VectorLayer layer = VectorLayer.of("test", Map.of("name", "string"));
+        TileJSON tileJSON = TileJSON.of("3.0.0", List.of("https://example.com/{z}/{x}/{y}.pbf"), List.of(layer));
+
+        // Test invalid bounds (west >= east)
+        assertThrows(IllegalArgumentException.class, () -> tileJSON.withBounds(10, -85, 10, 85));
+        assertThrows(IllegalArgumentException.class, () -> tileJSON.withBounds(10, -85, -10, 85));
+
+        // Test invalid bounds (south >= north)
+        assertThrows(IllegalArgumentException.class, () -> tileJSON.withBounds(-180, 85, 180, 85));
+        assertThrows(IllegalArgumentException.class, () -> tileJSON.withBounds(-180, 85, 180, -85));
+
+        // Test out of range bounds
+        assertThrows(IllegalArgumentException.class, () -> tileJSON.withBounds(-181, -85, 180, 85));
+        assertThrows(IllegalArgumentException.class, () -> tileJSON.withBounds(-180, -91, 180, 85));
+        assertThrows(IllegalArgumentException.class, () -> tileJSON.withBounds(-180, -85, 181, 85));
+        assertThrows(IllegalArgumentException.class, () -> tileJSON.withBounds(-180, -85, 180, 91));
+    }
+
+    @Test
+    void testCenterValidation() {
+        VectorLayer layer = VectorLayer.of("test", Map.of("name", "string"));
+        TileJSON tileJSON = TileJSON.of("3.0.0", List.of("https://example.com/{z}/{x}/{y}.pbf"), List.of(layer));
+
+        // Test invalid longitude
+        assertThrows(IllegalArgumentException.class, () -> tileJSON.withCenter(-181, 0, null));
+        assertThrows(IllegalArgumentException.class, () -> tileJSON.withCenter(181, 0, null));
+
+        // Test invalid latitude
+        assertThrows(IllegalArgumentException.class, () -> tileJSON.withCenter(0, -91, null));
+        assertThrows(IllegalArgumentException.class, () -> tileJSON.withCenter(0, 91, null));
+
+        // Test invalid zoom
+        assertThrows(IllegalArgumentException.class, () -> tileJSON.withCenter(0, 0, -1.0));
+        assertThrows(IllegalArgumentException.class, () -> tileJSON.withCenter(0, 0, 31.0));
+
+        // Test valid centers
+        assertDoesNotThrow(() -> tileJSON.withCenter(-180, -90, null));
+        assertDoesNotThrow(() -> tileJSON.withCenter(180, 90, null));
+        assertDoesNotThrow(() -> tileJSON.withCenter(0, 0, 0.0));
+        assertDoesNotThrow(() -> tileJSON.withCenter(0, 0, 30.0));
+    }
+
+    @Test
+    void testZoomValidation() {
+        VectorLayer layer = VectorLayer.of("test", Map.of("name", "string"));
+        TileJSON tileJSON = TileJSON.of("3.0.0", List.of("https://example.com/{z}/{x}/{y}.pbf"), List.of(layer));
+
+        // Test invalid zoom levels
+        assertThrows(IllegalArgumentException.class, () -> tileJSON.withZoomRange(-1, 10));
+        assertThrows(IllegalArgumentException.class, () -> tileJSON.withZoomRange(0, 31));
+        assertThrows(IllegalArgumentException.class, () -> tileJSON.withZoomRange(10, 5));
+
+        // Test valid zoom ranges
+        assertDoesNotThrow(() -> tileJSON.withZoomRange(0, 0));
+        assertDoesNotThrow(() -> tileJSON.withZoomRange(0, 30));
+        assertDoesNotThrow(() -> tileJSON.withZoomRange(null, 10));
+        assertDoesNotThrow(() -> tileJSON.withZoomRange(5, null));
+    }
+
+    @Test
+    void testJSONDeserialization() throws Exception {
+        String json =
+                """
+            {
+                "tilejson": "3.0.0",
+                "tiles": ["https://example.com/{z}/{x}/{y}.pbf"],
+                "vector_layers": [
+                    {
+                        "id": "roads",
+                        "fields": {
+                            "name": "String",
+                            "highway": "String"
+                        },
+                        "description": "Road network",
+                        "minzoom": 6,
+                        "maxzoom": 18
+                    }
+                ],
+                "name": "Test Tileset",
+                "description": "A test tileset",
+                "attribution": "© Test",
+                "bounds": [-180, -85, 180, 85],
+                "center": [-74, 40.7, 10],
+                "minzoom": 0,
+                "maxzoom": 18,
+                "version": "1.0.0",
+                "unknown_property": "should be ignored"
+            }
+            """;
+
+        TileJSON tileJSON = objectMapper.readValue(json, TileJSON.class);
+
+        assertEquals("3.0.0", tileJSON.tilejson());
+        assertEquals("Test Tileset", tileJSON.name());
+        assertEquals("A test tileset", tileJSON.description());
+        assertEquals("© Test", tileJSON.attribution());
+        assertEquals("1.0.0", tileJSON.version());
+
+        assertEquals(1, tileJSON.tiles().size());
+        assertEquals("https://example.com/{z}/{x}/{y}.pbf", tileJSON.tiles().get(0));
+
+        assertEquals(4, tileJSON.bounds().size());
+        assertEquals(-180.0, tileJSON.bounds().get(0));
+
+        assertEquals(3, tileJSON.center().size());
+        assertEquals(-74.0, tileJSON.center().get(0));
+        assertEquals(40.7, tileJSON.center().get(1));
+        assertEquals(10.0, tileJSON.center().get(2));
+
+        assertEquals(Integer.valueOf(0), tileJSON.minzoom());
+        assertEquals(Integer.valueOf(18), tileJSON.maxzoom());
+
+        assertEquals(1, tileJSON.vectorLayers().size());
+        VectorLayer layer = tileJSON.vectorLayers().get(0);
+        assertEquals("roads", layer.id());
+        assertEquals("Road network", layer.description());
+        assertEquals(Integer.valueOf(6), layer.minZoom());
+        assertEquals(Integer.valueOf(18), layer.maxZoom());
+        assertEquals("String", layer.fields().get("name"));
+        assertEquals("String", layer.fields().get("highway"));
+    }
+
+    @Test
+    void testBuilderMethods() {
+        VectorLayer layer = VectorLayer.of("test", Map.of("name", "string"));
+        TileJSON original = TileJSON.of("3.0.0", List.of("https://example.com/{z}/{x}/{y}.pbf"), List.of(layer));
+
+        // Test all builder methods
+        TileJSON modified = original.withName("New Name")
+                .withDescription("New Description")
+                .withAttribution("New Attribution")
+                .withVersion("2.0.0")
+                .withBounds(-90, -45, 90, 45)
+                .withCenter(0, 0, 5.0)
+                .withZoomRange(2, 14);
+
+        assertEquals("New Name", modified.name());
+        assertEquals("New Description", modified.description());
+        assertEquals("New Attribution", modified.attribution());
+        assertEquals("2.0.0", modified.version());
+        assertEquals(List.of(-90.0, -45.0, 90.0, 45.0), modified.bounds());
+        assertEquals(List.of(0.0, 0.0, 5.0), modified.center());
+        assertEquals(Integer.valueOf(2), modified.minzoom());
+        assertEquals(Integer.valueOf(14), modified.maxzoom());
+
+        // Original should be unchanged (immutability)
+        assertNull(original.name());
+        assertNull(original.description());
+        assertNull(original.attribution());
+    }
+}

--- a/src/tileverse-pmtiles-reader/src/test/java/io/tileverse/jackson/databind/tilejson/v3/TilesetTypeTest.java
+++ b/src/tileverse-pmtiles-reader/src/test/java/io/tileverse/jackson/databind/tilejson/v3/TilesetTypeTest.java
@@ -1,0 +1,172 @@
+/*
+ * (c) Copyright 2025 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.jackson.databind.tilejson.v3;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for TilesetType enum following TileJSON v3.0.0 specification.
+ */
+class TilesetTypeTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void testEnumValues() {
+        assertEquals("baselayer", TilesetType.BASELAYER.getValue());
+        assertEquals("overlay", TilesetType.OVERLAY.getValue());
+
+        assertEquals("baselayer", TilesetType.BASELAYER.toString());
+        assertEquals("overlay", TilesetType.OVERLAY.toString());
+    }
+
+    @Test
+    void testFromValueCaseSensitivity() {
+        // Test exact matches
+        assertEquals(TilesetType.BASELAYER, TilesetType.fromValue("baselayer"));
+        assertEquals(TilesetType.OVERLAY, TilesetType.fromValue("overlay"));
+
+        // Test case insensitivity
+        assertEquals(TilesetType.BASELAYER, TilesetType.fromValue("BASELAYER"));
+        assertEquals(TilesetType.BASELAYER, TilesetType.fromValue("BaseLayer"));
+        assertEquals(TilesetType.OVERLAY, TilesetType.fromValue("OVERLAY"));
+        assertEquals(TilesetType.OVERLAY, TilesetType.fromValue("Overlay"));
+
+        // Test with whitespace
+        assertEquals(TilesetType.BASELAYER, TilesetType.fromValue("  baselayer  "));
+        assertEquals(TilesetType.OVERLAY, TilesetType.fromValue("  overlay  "));
+    }
+
+    @Test
+    void testFromValueUnknownValues() {
+        // Test unknown values return null (forward compatibility)
+        assertNull(TilesetType.fromValue("unknown"));
+        assertNull(TilesetType.fromValue("custom"));
+        assertNull(TilesetType.fromValue("baselayers")); // plural
+        assertNull(TilesetType.fromValue("overlays")); // plural
+        assertNull(TilesetType.fromValue(""));
+        assertNull(TilesetType.fromValue("   "));
+        assertNull(TilesetType.fromValue(null));
+    }
+
+    @Test
+    void testJacksonSerialization() throws Exception {
+        // Test serialization of enum values
+        String baselayerJson = objectMapper.writeValueAsString(TilesetType.BASELAYER);
+        assertEquals("\"baselayer\"", baselayerJson);
+
+        String overlayJson = objectMapper.writeValueAsString(TilesetType.OVERLAY);
+        assertEquals("\"overlay\"", overlayJson);
+    }
+
+    @Test
+    void testJacksonDeserialization() throws Exception {
+        // Test deserialization of known values
+        TilesetType baselayer = objectMapper.readValue("\"baselayer\"", TilesetType.class);
+        assertEquals(TilesetType.BASELAYER, baselayer);
+
+        TilesetType overlay = objectMapper.readValue("\"overlay\"", TilesetType.class);
+        assertEquals(TilesetType.OVERLAY, overlay);
+
+        // Test case insensitivity in JSON
+        TilesetType baselayerUpper = objectMapper.readValue("\"BASELAYER\"", TilesetType.class);
+        assertEquals(TilesetType.BASELAYER, baselayerUpper);
+    }
+
+    @Test
+    void testJacksonDeserializationUnknownValues() throws Exception {
+        // Test unknown values deserialize to null (forward compatibility)
+        TilesetType unknown = objectMapper.readValue("\"unknown_type\"", TilesetType.class);
+        assertNull(unknown);
+
+        TilesetType empty = objectMapper.readValue("\"\"", TilesetType.class);
+        assertNull(empty);
+    }
+
+    @Test
+    void testJacksonInObjectContext() throws Exception {
+        // Test TilesetType within a JSON object context
+        String json =
+                """
+            {
+                "name": "Test Map",
+                "type": "baselayer"
+            }
+            """;
+
+        // Simple record to test context
+        record TestMetadata(String name, TilesetType type) {}
+
+        TestMetadata metadata = objectMapper.readValue(json, TestMetadata.class);
+        assertEquals("Test Map", metadata.name());
+        assertEquals(TilesetType.BASELAYER, metadata.type());
+
+        // Test serialization back
+        String serialized = objectMapper.writeValueAsString(metadata);
+        assertTrue(serialized.contains("\"type\":\"baselayer\""));
+    }
+
+    @Test
+    void testJacksonInObjectContextUnknownValue() throws Exception {
+        // Test unknown value in object context (should be null)
+        String json =
+                """
+            {
+                "name": "Test Map",
+                "type": "unknown_type"
+            }
+            """;
+
+        record TestMetadata(String name, TilesetType type) {}
+
+        TestMetadata metadata = objectMapper.readValue(json, TestMetadata.class);
+        assertEquals("Test Map", metadata.name());
+        assertNull(metadata.type());
+    }
+
+    @Test
+    void testAllEnumValues() {
+        // Ensure we have exactly the expected enum values
+        TilesetType[] values = TilesetType.values();
+        assertEquals(2, values.length);
+
+        boolean hasBaselayer = false;
+        boolean hasOverlay = false;
+
+        for (TilesetType type : values) {
+            switch (type) {
+                case BASELAYER -> hasBaselayer = true;
+                case OVERLAY -> hasOverlay = true;
+            }
+        }
+
+        assertTrue(hasBaselayer, "Should have BASELAYER enum value");
+        assertTrue(hasOverlay, "Should have OVERLAY enum value");
+    }
+
+    @Test
+    void testRoundTripSerialization() throws Exception {
+        // Test that we can serialize and deserialize without data loss
+        for (TilesetType type : TilesetType.values()) {
+            String json = objectMapper.writeValueAsString(type);
+            TilesetType deserialized = objectMapper.readValue(json, TilesetType.class);
+            assertEquals(type, deserialized, "Round-trip serialization failed for " + type);
+        }
+    }
+}

--- a/src/tileverse-pmtiles-reader/src/test/java/io/tileverse/jackson/databind/tilejson/v3/VectorLayerTest.java
+++ b/src/tileverse-pmtiles-reader/src/test/java/io/tileverse/jackson/databind/tilejson/v3/VectorLayerTest.java
@@ -1,0 +1,234 @@
+/*
+ * (c) Copyright 2025 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.jackson.databind.tilejson.v3;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for VectorLayer following TileJSON v3.0.0 specification.
+ */
+class VectorLayerTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void testMinimalVectorLayer() throws Exception {
+        Map<String, String> fields = Map.of("name", "String", "type", "String");
+        VectorLayer layer = VectorLayer.of("buildings", fields);
+
+        assertEquals("buildings", layer.id());
+        assertEquals(fields, layer.fields());
+        assertNull(layer.description());
+        assertNull(layer.minZoom());
+        assertNull(layer.maxZoom());
+
+        // Test serialization
+        String json = objectMapper.writeValueAsString(layer);
+        assertTrue(json.contains("\"id\":\"buildings\""));
+        assertTrue(json.contains("\"fields\":{"));
+        assertTrue(json.contains("\"name\":\"String\""));
+
+        // Test deserialization
+        VectorLayer deserialized = objectMapper.readValue(json, VectorLayer.class);
+        assertEquals(layer.id(), deserialized.id());
+        assertEquals(layer.fields(), deserialized.fields());
+    }
+
+    @Test
+    void testCompleteVectorLayer() throws Exception {
+        Map<String, String> fields = Map.of(
+                "name", "String",
+                "height", "Number",
+                "residential", "Boolean");
+
+        VectorLayer layer = VectorLayer.of("buildings", fields, "Building footprints", 12, 18);
+
+        assertEquals("buildings", layer.id());
+        assertEquals(fields, layer.fields());
+        assertEquals("Building footprints", layer.description());
+        assertEquals(Integer.valueOf(12), layer.minZoom());
+        assertEquals(Integer.valueOf(18), layer.maxZoom());
+
+        // Test serialization/deserialization
+        String json = objectMapper.writeValueAsString(layer);
+        VectorLayer deserialized = objectMapper.readValue(json, VectorLayer.class);
+
+        assertEquals(layer.id(), deserialized.id());
+        assertEquals(layer.fields(), deserialized.fields());
+        assertEquals(layer.description(), deserialized.description());
+        assertEquals(layer.minZoom(), deserialized.minZoom());
+        assertEquals(layer.maxZoom(), deserialized.maxZoom());
+    }
+
+    @Test
+    void testRequiredFieldValidation() {
+        Map<String, String> fields = Map.of("name", "String");
+
+        // Test null id
+        assertThrows(IllegalArgumentException.class, () -> VectorLayer.of(null, fields));
+
+        // Test blank id
+        assertThrows(IllegalArgumentException.class, () -> VectorLayer.of("", fields));
+        assertThrows(IllegalArgumentException.class, () -> VectorLayer.of("   ", fields));
+
+        // Test null fields
+        assertThrows(IllegalArgumentException.class, () -> VectorLayer.of("test", null));
+
+        // Test valid creation
+        assertDoesNotThrow(() -> VectorLayer.of("test", fields));
+    }
+
+    @Test
+    void testZoomValidation() {
+        Map<String, String> fields = Map.of("name", "String");
+
+        // Test invalid minZoom
+        assertThrows(IllegalArgumentException.class, () -> VectorLayer.of("test", fields, null, -1, 10));
+        assertThrows(IllegalArgumentException.class, () -> VectorLayer.of("test", fields, null, 31, 10));
+
+        // Test invalid maxZoom
+        assertThrows(IllegalArgumentException.class, () -> VectorLayer.of("test", fields, null, 5, -1));
+        assertThrows(IllegalArgumentException.class, () -> VectorLayer.of("test", fields, null, 5, 31));
+
+        // Test minZoom > maxZoom
+        assertThrows(IllegalArgumentException.class, () -> VectorLayer.of("test", fields, null, 10, 5));
+
+        // Test valid zoom ranges
+        assertDoesNotThrow(() -> VectorLayer.of("test", fields, null, 0, 30));
+        assertDoesNotThrow(() -> VectorLayer.of("test", fields, null, 5, 5));
+        assertDoesNotThrow(() -> VectorLayer.of("test", fields, null, null, 10));
+        assertDoesNotThrow(() -> VectorLayer.of("test", fields, null, 5, null));
+    }
+
+    @Test
+    void testBuilderMethods() {
+        Map<String, String> originalFields = Map.of("name", "String");
+        Map<String, String> newFields = Map.of("name", "String", "type", "String");
+
+        VectorLayer original = VectorLayer.of("test", originalFields);
+
+        // Test builder methods
+        VectorLayer modified = original.withDescription("Test description")
+                .withZoomRange(5, 15)
+                .withFields(newFields);
+
+        assertEquals("test", modified.id()); // id should remain the same
+        assertEquals("Test description", modified.description());
+        assertEquals(Integer.valueOf(5), modified.minZoom());
+        assertEquals(Integer.valueOf(15), modified.maxZoom());
+        assertEquals(newFields, modified.fields());
+
+        // Original should be unchanged (immutability)
+        assertNull(original.description());
+        assertNull(original.minZoom());
+        assertNull(original.maxZoom());
+        assertEquals(originalFields, original.fields());
+    }
+
+    @Test
+    void testBuilderValidation() {
+        Map<String, String> fields = Map.of("name", "String");
+        VectorLayer layer = VectorLayer.of("test", fields);
+
+        // Test zoom range validation in builder methods
+        assertThrows(IllegalArgumentException.class, () -> layer.withZoomRange(-1, 10));
+        assertThrows(IllegalArgumentException.class, () -> layer.withZoomRange(10, 31));
+        assertThrows(IllegalArgumentException.class, () -> layer.withZoomRange(15, 5));
+
+        // Test fields validation in builder method
+        assertThrows(IllegalArgumentException.class, () -> layer.withFields(null));
+    }
+
+    @Test
+    void testJSONDeserialization() throws Exception {
+        String json =
+                """
+            {
+                "id": "roads",
+                "fields": {
+                    "name": "String",
+                    "highway": "String",
+                    "oneway": "Boolean",
+                    "lanes": "Number"
+                },
+                "description": "Road network data",
+                "minzoom": 6,
+                "maxzoom": 18,
+                "unknown_property": "should be ignored"
+            }
+            """;
+
+        VectorLayer layer = objectMapper.readValue(json, VectorLayer.class);
+
+        assertEquals("roads", layer.id());
+        assertEquals("Road network data", layer.description());
+        assertEquals(Integer.valueOf(6), layer.minZoom());
+        assertEquals(Integer.valueOf(18), layer.maxZoom());
+
+        assertNotNull(layer.fields());
+        assertEquals(4, layer.fields().size());
+        assertEquals("String", layer.fields().get("name"));
+        assertEquals("String", layer.fields().get("highway"));
+        assertEquals("Boolean", layer.fields().get("oneway"));
+        assertEquals("Number", layer.fields().get("lanes"));
+    }
+
+    @Test
+    void testEmptyFields() throws Exception {
+        // Test with empty fields map (valid per TileJSON spec)
+        Map<String, String> emptyFields = Map.of();
+        VectorLayer layer = VectorLayer.of("buildings", emptyFields);
+
+        assertEquals("buildings", layer.id());
+        assertTrue(layer.fields().isEmpty());
+
+        // Test serialization/deserialization
+        String json = objectMapper.writeValueAsString(layer);
+        VectorLayer deserialized = objectMapper.readValue(json, VectorLayer.class);
+
+        assertEquals(layer.id(), deserialized.id());
+        assertTrue(deserialized.fields().isEmpty());
+    }
+
+    @Test
+    void testFieldTypes() throws Exception {
+        // Test various field types commonly used in vector tiles
+        Map<String, String> fields = Map.of(
+                "id", "Number",
+                "name", "String",
+                "visible", "Boolean",
+                "area", "Number",
+                "tags", "String",
+                "custom_type", "CustomType" // Should allow any string value
+                );
+
+        VectorLayer layer = VectorLayer.of("features", fields);
+
+        // Test serialization preserves all field types
+        String json = objectMapper.writeValueAsString(layer);
+        VectorLayer deserialized = objectMapper.readValue(json, VectorLayer.class);
+
+        assertEquals(fields, deserialized.fields());
+        assertEquals("Number", deserialized.fields().get("id"));
+        assertEquals("String", deserialized.fields().get("name"));
+        assertEquals("Boolean", deserialized.fields().get("visible"));
+        assertEquals("CustomType", deserialized.fields().get("custom_type"));
+    }
+}


### PR DESCRIPTION
Implement a complete object model for PMTiles metadata parsing and TileJSON v3.0.0 specification compliance with Jackson databind support.

PMTiles Enhancements

- Add comprehensive javadoc to PMTilesHeader constructor parameters based on PMTiles v3 spec
- Add utility methods to convert E7 encoded coordinates to double values: minLon(), minLat(), maxLon(), maxLat(), centerLon(), centerLat()
- Update PMTilesReader.getMetadata() to return structured PMTilesMetadata object
- Implement PMTilesMetadata following actual PMTiles v3 specification (not full TileJSON)

TileJSON v3.0.0 Implementation

- Create complete TileJSON v3.0.0 object model with schema compliance
- Implement VectorLayer with field definitions, zoom ranges, and validation
- Add TilesetType enum with forward compatibility for unknown values
- Include comprehensive validation for bounds, center coordinates, and zoom levels
- Support arbitrary field types in vector layer definitions