### PR TITLE
Add tileverse-tilepyramid module with unified tiling model

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,18 +135,23 @@
 
       <!-- Internal modules -->
       <dependency>
+        <groupId>io.tileverse.vectortiles</groupId>
+        <artifactId>tileverse-vectortiles</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
         <groupId>io.tileverse.pmtiles</groupId>
         <artifactId>tileverse-pmtiles-test-data</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>io.tileverse.pmtiles</groupId>
-        <artifactId>tileverse-pmtiles-reader</artifactId>
+        <artifactId>tileverse-tilepyramid</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>io.tileverse.vectortiles</groupId>
-        <artifactId>tileverse-vectortiles</artifactId>
+        <groupId>io.tileverse.pmtiles</groupId>
+        <artifactId>tileverse-pmtiles-reader</artifactId>
         <version>${project.version}</version>
       </dependency>
 

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -13,6 +13,7 @@
 
   <modules>
     <module>tileverse-vectortiles</module>
+    <module>tileverse-tilepyramid</module>
     <module>tileverse-pmtiles-reader</module>
   </modules>
 

--- a/src/tileverse-pmtiles-reader/src/main/java/io/tileverse/pmtiles/PMTilesTileMatrixSet.java
+++ b/src/tileverse-pmtiles-reader/src/main/java/io/tileverse/pmtiles/PMTilesTileMatrixSet.java
@@ -1,0 +1,157 @@
+/*
+ * (c) Copyright 2025 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.pmtiles;
+
+import io.tileverse.tiling.grid.DefaultTileMatrixSets;
+import io.tileverse.tiling.grid.Extent;
+import io.tileverse.tiling.grid.TileMatrixSet;
+
+/**
+ * Factory methods for creating TileMatrixSet instances from PMTiles data.
+ * Provides convenient methods to create tile matrix sets that match the
+ * coverage and zoom levels of PMTiles files.
+ *
+ * @since 1.0
+ */
+public class PMTilesTileMatrixSet {
+
+    // Constants for WebMercator coordinate transformation
+    private static final double EARTH_RADIUS = 6378137.0; // WGS84 semi-major axis
+    private static final double ORIGIN_SHIFT = Math.PI * EARTH_RADIUS;
+
+    /**
+     * Creates a WebMercator TileMatrixSet that matches both the zoom level range
+     * and geographic bounds defined in a PMTiles header. Uses the standard OGC
+     * WebMercatorQuad tile matrix set as the base and creates a subset covering
+     * only the tiles that intersect with the PMTiles bounding box.
+     *
+     * <p>This assumes the PMTiles uses WebMercator projection (EPSG:3857),
+     * which is the most common case for PMTiles files.
+     *
+     * @param pmtilesHeader the PMTiles header containing zoom level and bounds information
+     * @return a TileMatrixSet covering the PMTiles geographic and zoom extent
+     * @throws IllegalArgumentException if the zoom range is invalid
+     */
+    public static TileMatrixSet fromWebMercator(PMTilesHeader pmtilesHeader) {
+        // Convert PMTiles lat/lon bounds to WebMercator extent
+        Extent webMercatorExtent = latLonToWebMercator(
+                pmtilesHeader.minLon(), pmtilesHeader.minLat(),
+                pmtilesHeader.maxLon(), pmtilesHeader.maxLat());
+
+        // Get zoom-level subset and spatial intersection in one step
+        TileMatrixSet baseTms = DefaultTileMatrixSets.WEB_MERCATOR_QUAD.toBuilder()
+                .zoomRange(pmtilesHeader.minZoom(), pmtilesHeader.maxZoom())
+                .build();
+
+        return baseTms.intersection(webMercatorExtent).orElse(baseTms);
+    }
+
+    /**
+     * Creates a WebMercator TileMatrixSet with 512px tiles that matches both the
+     * zoom level range and geographic bounds defined in a PMTiles header.
+     * Uses the standard OGC WebMercatorQuad x2 tile matrix set as the base.
+     *
+     * @param pmtilesHeader the PMTiles header containing zoom level and bounds information
+     * @return a TileMatrixSet with 512px tiles covering the PMTiles extent
+     * @throws IllegalArgumentException if the zoom range is invalid
+     */
+    public static TileMatrixSet fromWebMercator512(PMTilesHeader pmtilesHeader) {
+        // Convert PMTiles lat/lon bounds to WebMercator extent
+        Extent webMercatorExtent = latLonToWebMercator(
+                pmtilesHeader.minLon(), pmtilesHeader.minLat(),
+                pmtilesHeader.maxLon(), pmtilesHeader.maxLat());
+
+        // Get zoom-level subset and spatial intersection
+        TileMatrixSet baseTms = DefaultTileMatrixSets.WEB_MERCATOR_QUADx2.toBuilder()
+                .zoomRange(pmtilesHeader.minZoom(), pmtilesHeader.maxZoom())
+                .build();
+
+        return baseTms.intersection(webMercatorExtent).orElse(baseTms);
+    }
+
+    /**
+     * Creates a geographic (EPSG:4326) TileMatrixSet that matches both the zoom level range
+     * and geographic bounds defined in a PMTiles header. Uses the standard WorldCRS84Quad
+     * tile matrix set as the base.
+     *
+     * @param pmtilesHeader the PMTiles header containing zoom level and bounds information
+     * @return a TileMatrixSet covering the PMTiles extent in EPSG:4326
+     * @throws IllegalArgumentException if the zoom range is invalid
+     */
+    public static TileMatrixSet fromCRS84(PMTilesHeader pmtilesHeader) {
+        // PMTiles bounds are already in lat/lon, create extent directly
+        Extent latLonExtent = Extent.of(
+                pmtilesHeader.minLon(), pmtilesHeader.minLat(),
+                pmtilesHeader.maxLon(), pmtilesHeader.maxLat());
+
+        // Get zoom-level subset and spatial intersection
+        TileMatrixSet baseTms = DefaultTileMatrixSets.WORLD_CRS84_QUAD.toBuilder()
+                .zoomRange(pmtilesHeader.minZoom(), pmtilesHeader.maxZoom())
+                .build();
+
+        return baseTms.intersection(latLonExtent).orElse(baseTms);
+    }
+
+    /**
+     * Creates a WebMercator TileMatrixSet from a PMTilesReader.
+     * Convenience method that extracts the header and creates the tile matrix set.
+     *
+     * @param pmtilesReader the PMTiles reader
+     * @return a TileMatrixSet covering the PMTiles zoom range
+     * @throws IllegalArgumentException if the zoom range is invalid
+     */
+    public static TileMatrixSet fromWebMercator(PMTilesReader pmtilesReader) {
+        return fromWebMercator(pmtilesReader.getHeader());
+    }
+
+    /**
+     * Creates a geographic (EPSG:4326) TileMatrixSet from a PMTilesReader.
+     * Convenience method that extracts the header and creates the tile matrix set.
+     *
+     * @param pmtilesReader the PMTiles reader
+     * @return a TileMatrixSet covering the PMTiles zoom range in EPSG:4326
+     * @throws IllegalArgumentException if the zoom range is invalid
+     */
+    public static TileMatrixSet fromCRS84(PMTilesReader pmtilesReader) {
+        return fromCRS84(pmtilesReader.getHeader());
+    }
+
+    /**
+     * Converts lat/lon coordinates to WebMercator (EPSG:3857) extent.
+     * Uses the spherical Mercator projection formula.
+     *
+     * @param minLon minimum longitude in degrees
+     * @param minLat minimum latitude in degrees
+     * @param maxLon maximum longitude in degrees
+     * @param maxLat maximum latitude in degrees
+     * @return WebMercator extent in meters
+     */
+    private static Extent latLonToWebMercator(double minLon, double minLat, double maxLon, double maxLat) {
+        // Clamp latitude to valid Mercator range
+        minLat = Math.max(-85.0511, Math.min(85.0511, minLat));
+        maxLat = Math.max(-85.0511, Math.min(85.0511, maxLat));
+
+        // Convert longitude to WebMercator X
+        double minX = minLon * ORIGIN_SHIFT / 180.0;
+        double maxX = maxLon * ORIGIN_SHIFT / 180.0;
+
+        // Convert latitude to WebMercator Y using spherical Mercator formula
+        double minY = Math.log(Math.tan((90.0 + minLat) * Math.PI / 360.0)) * EARTH_RADIUS;
+        double maxY = Math.log(Math.tan((90.0 + maxLat) * Math.PI / 360.0)) * EARTH_RADIUS;
+
+        return Extent.of(minX, minY, maxX, maxY);
+    }
+}

--- a/src/tileverse-pmtiles-reader/src/test/java/io/tileverse/pmtiles/PMTilesTileMatrixSetTest.java
+++ b/src/tileverse-pmtiles-reader/src/test/java/io/tileverse/pmtiles/PMTilesTileMatrixSetTest.java
@@ -1,0 +1,135 @@
+/*
+ * (c) Copyright 2025 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.pmtiles;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.tileverse.tiling.grid.TileMatrixSet;
+import org.junit.jupiter.api.Test;
+
+class PMTilesTileMatrixSetTest {
+
+    @Test
+    void testFromWebMercator() {
+        // Create a test header with zoom levels 5-15 and NYC bounds
+        PMTilesHeader header = PMTilesHeader.builder()
+                .minZoom((byte) 5)
+                .maxZoom((byte) 15)
+                .minLon(-74.1) // NYC west
+                .minLat(40.6) // NYC south
+                .maxLon(-73.9) // NYC east
+                .maxLat(40.8) // NYC north
+                .build();
+
+        TileMatrixSet tms = PMTilesTileMatrixSet.fromWebMercator(header);
+
+        assertNotNull(tms);
+        assertEquals("EPSG:3857", tms.crsId());
+        assertEquals(256, tms.tileWidth());
+        assertEquals(256, tms.tileHeight());
+
+        // Check zoom level range
+        assertEquals(5, tms.tilePyramid().minZoomLevel());
+        assertEquals(15, tms.tilePyramid().maxZoomLevel());
+
+        // Check that we have the correct number of levels
+        assertEquals(11, tms.tilePyramid().levels().size()); // 5-15 inclusive = 11 levels
+
+        // Verify that tile ranges are smaller than full world (due to NYC bounds)
+        // At zoom level 5, full world would be 32x32 tiles, but NYC should be much smaller
+        io.tileverse.tiling.model.TileRange level5Range = tms.tilePyramid().tileRange(5);
+        assertTrue(level5Range.count() < 32 * 32, "NYC bounds should result in fewer tiles than full world");
+        assertTrue(level5Range.count() > 0, "Should have some tiles in the bounded area");
+    }
+
+    @Test
+    void testFromWebMercator512() {
+        PMTilesHeader header = PMTilesHeader.builder()
+                .minZoom((byte) 3)
+                .maxZoom((byte) 10)
+                .minLon(-1.0)
+                .minLat(51.0)
+                .maxLon(1.0)
+                .maxLat(52.0) // London area
+                .build();
+
+        TileMatrixSet tms = PMTilesTileMatrixSet.fromWebMercator512(header);
+
+        assertNotNull(tms);
+        assertEquals("EPSG:3857", tms.crsId());
+        assertEquals(512, tms.tileWidth());
+        assertEquals(512, tms.tileHeight());
+
+        assertEquals(3, tms.tilePyramid().minZoomLevel());
+        assertEquals(10, tms.tilePyramid().maxZoomLevel());
+        assertEquals(8, tms.tilePyramid().levels().size()); // 3-10 inclusive = 8 levels
+    }
+
+    @Test
+    void testFromCRS84() {
+        PMTilesHeader header =
+                PMTilesHeader.builder().minZoom((byte) 2).maxZoom((byte) 8).build();
+
+        TileMatrixSet tms = PMTilesTileMatrixSet.fromCRS84(header);
+
+        assertNotNull(tms);
+        assertEquals("EPSG:4326", tms.crsId());
+        assertEquals(256, tms.tileWidth());
+        assertEquals(256, tms.tileHeight());
+
+        assertEquals(2, tms.tilePyramid().minZoomLevel());
+        assertEquals(8, tms.tilePyramid().maxZoomLevel());
+        assertEquals(7, tms.tilePyramid().levels().size()); // 2-8 inclusive = 7 levels
+    }
+
+    @Test
+    void testResolutionsAreCorrect() {
+        PMTilesHeader header =
+                PMTilesHeader.builder().minZoom((byte) 0).maxZoom((byte) 2).build();
+
+        TileMatrixSet tms = PMTilesTileMatrixSet.fromWebMercator(header);
+
+        // Test that resolutions decrease (become more detailed) as zoom increases
+        double res0 = tms.resolution(0);
+        double res1 = tms.resolution(1);
+        double res2 = tms.resolution(2);
+
+        assertTrue(res0 > res1, "Resolution should decrease from zoom 0 to 1");
+        assertTrue(res1 > res2, "Resolution should decrease from zoom 1 to 2");
+
+        // Test that resolutions roughly double between levels (within precision)
+        double ratio1 = res0 / res1;
+        double ratio2 = res1 / res2;
+
+        assertTrue(Math.abs(ratio1 - 2.0) < 0.1, "Resolution ratio should be close to 2.0, was: " + ratio1);
+        assertTrue(Math.abs(ratio2 - 2.0) < 0.1, "Resolution ratio should be close to 2.0, was: " + ratio2);
+    }
+
+    @Test
+    void testInvalidZoomRange() {
+        PMTilesHeader header = PMTilesHeader.builder()
+                .minZoom((byte) 30) // Beyond available zoom levels
+                .maxZoom((byte) 35)
+                .build();
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            PMTilesTileMatrixSet.fromWebMercator(header);
+        });
+    }
+}

--- a/src/tileverse-tilepyramid/pom.xml
+++ b/src/tileverse-tilepyramid/pom.xml
@@ -8,41 +8,27 @@
     <version>${revision}</version>
   </parent>
 
-  <artifactId>tileverse-pmtiles-reader</artifactId>
-  <name>Tileverse - Core</name>
-  <description>Core PMTiles format implementation</description>
+  <artifactId>tileverse-tilepyramid</artifactId>
+  <name>Tileverse Tile Pyramid Model</name>
+  <description>Generic object model for defining tile pyramids and tiling schemes</description>
 
   <dependencies>
+    <!-- JTS for geometric operations -->
     <dependency>
-      <groupId>io.tileverse.rangereader</groupId>
-      <artifactId>tileverse-rangereader-all</artifactId>
+      <groupId>org.locationtech.jts</groupId>
+      <artifactId>jts-core</artifactId>
     </dependency>
 
-    <!-- Compression -->
+    <!-- Jackson for JSON serialization -->
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-compress</artifactId>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.github.luben</groupId>
-      <artifactId>zstd-jni</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.tileverse.vectortiles</groupId>
-      <artifactId>tileverse-vectortiles</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.tileverse.pmtiles</groupId>
-      <artifactId>tileverse-tilepyramid</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.tileverse.pmtiles</groupId>
-      <artifactId>tileverse-pmtiles-test-data</artifactId>
-      <scope>test</scope>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
     </dependency>
   </dependencies>
-
   <build>
     <plugins>
       <plugin>

--- a/src/tileverse-tilepyramid/src/main/java/io/tileverse/tiling/grid/Coordinate.java
+++ b/src/tileverse-tilepyramid/src/main/java/io/tileverse/tiling/grid/Coordinate.java
@@ -1,0 +1,76 @@
+/*
+ * (c) Copyright 2025 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.tiling.grid;
+
+/**
+ * Represents a 2D coordinate in map space (CRS coordinates).
+ * This is a simple, GIS-library-agnostic representation that can easily
+ * be converted to/from coordinates in various GIS libraries.
+ *
+ * <p>The coordinate values can represent:
+ * <ul>
+ * <li>Geographic coordinates (longitude, latitude) in degrees</li>
+ * <li>Projected coordinates (easting, northing) in meters or other units</li>
+ * <li>Any other 2D coordinate system values</li>
+ * </ul>
+ *
+ * @param x the X coordinate (typically longitude or easting)
+ * @param y the Y coordinate (typically latitude or northing)
+ * @since 1.0
+ */
+public record Coordinate(double x, double y) {
+
+    /**
+     * Creates a coordinate with the specified X and Y values.
+     *
+     * @param x the X coordinate
+     * @param y the Y coordinate
+     * @return a new Coordinate instance
+     */
+    public static Coordinate of(double x, double y) {
+        return new Coordinate(x, y);
+    }
+
+    /**
+     * Returns a coordinate offset by the specified amounts.
+     *
+     * @param deltaX the X offset
+     * @param deltaY the Y offset
+     * @return a new coordinate offset by the specified amounts
+     */
+    public Coordinate offset(double deltaX, double deltaY) {
+        return new Coordinate(x + deltaX, y + deltaY);
+    }
+
+    /**
+     * Returns the distance to another coordinate using Euclidean distance.
+     * This is appropriate for projected coordinate systems but not for
+     * geographic coordinates (longitude/latitude).
+     *
+     * @param other the other coordinate
+     * @return the Euclidean distance
+     */
+    public double distanceTo(Coordinate other) {
+        double dx = x - other.x;
+        double dy = y - other.y;
+        return Math.sqrt(dx * dx + dy * dy);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Coordinate(%.6f, %.6f)", x, y);
+    }
+}

--- a/src/tileverse-tilepyramid/src/main/java/io/tileverse/tiling/grid/DefaultTileMatrixSets.java
+++ b/src/tileverse-tilepyramid/src/main/java/io/tileverse/tiling/grid/DefaultTileMatrixSets.java
@@ -1,0 +1,327 @@
+/*
+ * (c) Copyright 2025 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.tiling.grid;
+
+import io.tileverse.tiling.model.AxisOrigin;
+import io.tileverse.tiling.model.TilePyramid;
+import io.tileverse.tiling.model.TileRange;
+
+/**
+ * Standard tile matrix sets commonly used in web mapping applications.
+ * Provides constants and factory methods for creating tile matrix sets compatible
+ * with GeoWebCache, OGC TMS specifications, and PMTiles.
+ *
+ * <p>This class includes the most commonly used tile matrix sets:
+ * <ul>
+ * <li>EPSG:4326 (WGS84) - Geographic coordinate system</li>
+ * <li>EPSG:3857 (Web Mercator) - Spherical Mercator projection</li>
+ * <li>OGC TMS WebMercatorQuad - Official OGC Tile Matrix Set</li>
+ * <li>OGC TMS WorldCRS84Quad - Official OGC geographic Tile Matrix Set</li>
+ * </ul>
+ *
+ * @since 1.0
+ */
+public class DefaultTileMatrixSets {
+
+    // Standard extents from GeoWebCache
+    public static final Extent WORLD4326 = Extent.of(-180.0, -90.0, 180.0, 90.0);
+    public static final Extent WORLD3857 = Extent.of(-20037508.34, -20037508.34, 20037508.34, 20037508.34);
+    public static final Extent WORLD3857_TMS =
+            Extent.of(-20037508.3427892, -20037508.3427892, 20037508.3427892, 20037508.3427892);
+
+    // Standard WebMercator resolutions (matching GeoWebCache commonPractice900913Resolutions)
+    private static final double[] WEBMERCATOR_RESOLUTIONS = {
+        156543.03390625,
+        78271.516953125,
+        39135.7584765625,
+        19567.87923828125,
+        9783.939619140625,
+        4891.9698095703125,
+        2445.9849047851562,
+        1222.9924523925781,
+        611.4962261962891,
+        305.74811309814453,
+        152.87405654907226,
+        76.43702827453613,
+        38.218514137268066,
+        19.109257068634033,
+        9.554628534317017,
+        4.777314267158508,
+        2.388657133579254,
+        1.194328566789627,
+        0.5971642833948135,
+        0.29858214169740677,
+        0.14929107084870338,
+        0.07464553542435169,
+        0.037322767712175846,
+        0.018661383856087923,
+        0.009330691928043961,
+        0.004665345964021981,
+        0.0023326729820109904,
+        0.0011663364910054952,
+        5.831682455027476E-4,
+        2.915841227513738E-4,
+        1.457920613756869E-4
+    };
+
+    // OGC TMS WebMercatorQuad scale denominators
+    private static final double[] WEBMERCATOR_QUAD_SCALES = {
+        559082264.028717,
+        279541132.014358,
+        139770566.007179,
+        69885283.0035897,
+        34942641.5017948,
+        17471320.7508974,
+        8735660.37544871,
+        4367830.18772435,
+        2183915.09386217,
+        1091957.54693108,
+        545978.773465544,
+        272989.386732772,
+        136494.693366386,
+        68247.346683193,
+        34123.6733415964,
+        17061.8366707982,
+        8530.91833539913,
+        4265.45916769956,
+        2132.72958384978,
+        1066.36479192489,
+        533.182395962445,
+        266.591197981222,
+        133.295598990611,
+        66.6477994953056,
+        33.3238997476528
+    };
+
+    // CRS84 (EPSG:4326) quad scale denominators
+    private static final double[] CRS84_QUAD_SCALES = {
+        279541132.0143589,
+        139770566.0071794,
+        69885283.00358972,
+        34942641.50179486,
+        17471320.75089743,
+        8735660.375448715,
+        4367830.187724357,
+        2183915.093862179,
+        1091957.546931089,
+        545978.7734655447,
+        272989.3867327723,
+        136494.6933663862,
+        68247.34668319309,
+        34123.67334159654,
+        17061.83667079827,
+        8530.918335399136,
+        4265.459167699568,
+        2132.729583849784,
+    };
+
+    // Default constants
+
+    /**
+     * EPSG:4326 (WGS84) tile matrix set - GlobalCRS84Geometric/EPSG:4326.
+     * Two tiles at zoom 0 (2x1), standard 256px tiles.
+     * Uses UPPER_LEFT axis origin compatible with PMTiles indexing.
+     */
+    public static final TileMatrixSet WORLD_EPSG4326 = createEPSG4326(256);
+
+    /**
+     * EPSG:4326 (WGS84) tile matrix set with 512px tiles.
+     * Uses UPPER_LEFT axis origin compatible with PMTiles indexing.
+     */
+    public static final TileMatrixSet WORLD_EPSG4326x2 = createEPSG4326(512);
+
+    /**
+     * EPSG:3857 (WebMercator) tile matrix set - GoogleMapsCompatible/EPSG:3857.
+     * Uses common practice resolutions, 256px tiles.
+     * Uses UPPER_LEFT axis origin compatible with PMTiles indexing.
+     */
+    public static final TileMatrixSet WORLD_EPSG3857 = createEPSG3857(256);
+
+    /**
+     * EPSG:3857 (WebMercator) tile matrix set with 512px tiles.
+     * Uses UPPER_LEFT axis origin compatible with PMTiles indexing.
+     */
+    public static final TileMatrixSet WORLD_EPSG3857x2 = createEPSG3857(512);
+
+    /**
+     * OGC TMS WebMercatorQuad - official OGC Tile Matrix Set.
+     * EPSG:3857 with precise scale denominators, 256px tiles.
+     * Uses UPPER_LEFT axis origin compatible with PMTiles indexing.
+     */
+    public static final TileMatrixSet WEB_MERCATOR_QUAD = createWebMercatorQuad(256);
+
+    /**
+     * OGC TMS WebMercatorQuad with 512px tiles.
+     * Uses UPPER_LEFT axis origin compatible with PMTiles indexing.
+     */
+    public static final TileMatrixSet WEB_MERCATOR_QUADx2 = createWebMercatorQuad(512);
+
+    /**
+     * OGC TMS WorldCRS84Quad - official OGC Tile Matrix Set.
+     * EPSG:4326 with precise scale denominators, 256px tiles.
+     * Uses UPPER_LEFT axis origin compatible with PMTiles indexing.
+     */
+    public static final TileMatrixSet WORLD_CRS84_QUAD = createWorldCRS84Quad(256);
+
+    /**
+     * OGC TMS WorldCRS84Quad with 512px tiles.
+     * Uses UPPER_LEFT axis origin compatible with PMTiles indexing.
+     */
+    public static final TileMatrixSet WORLD_CRS84_QUADx2 = createWorldCRS84Quad(512);
+
+    // Factory methods
+
+    private static TileMatrixSet createEPSG4326(int tileSize) {
+        // EPSG:4326 starts with 2 tiles horizontally, 1 vertically at zoom 0
+        TilePyramid.Builder pyramidBuilder =
+                TilePyramid.builder().axisOrigin(AxisOrigin.UPPER_LEFT); // Geographic typically uses upper-left
+
+        int maxZoom = 21; // Standard max for EPSG:4326
+        for (int z = 0; z <= maxZoom; z++) {
+            long tilesWide = 2L << z; // 2 * 2^z
+            long tilesHigh = 1L << z; // 1 * 2^z
+            TileRange range = TileRange.of(0, 0, tilesWide - 1, tilesHigh - 1, z, AxisOrigin.UPPER_LEFT);
+            pyramidBuilder.level(range);
+        }
+
+        TilePyramid pyramid = pyramidBuilder.build();
+
+        // Calculate resolutions and origins
+        double[] resolutions = new double[maxZoom + 1];
+        Coordinate[] origins = new Coordinate[maxZoom + 1];
+
+        for (int z = 0; z <= maxZoom; z++) {
+            // Geographic resolution: 360 degrees / (tileSize * 2 * 2^z)
+            resolutions[z] = 360.0 / (tileSize * 2 * (1L << z));
+            // Origin is always top-left of world bounds
+            origins[z] = Coordinate.of(-180.0, 90.0);
+        }
+
+        return TileMatrixSet.builder()
+                .tilePyramid(pyramid)
+                .crs("EPSG:4326")
+                .tileSize(tileSize, tileSize)
+                .extent(WORLD4326)
+                .resolutions(resolutions)
+                .origins(origins)
+                .build();
+    }
+
+    private static TileMatrixSet createEPSG3857(int tileSize) {
+        TilePyramid.Builder pyramidBuilder =
+                TilePyramid.builder().axisOrigin(AxisOrigin.UPPER_LEFT); // Match PMTiles indexing
+
+        int maxZoom = WEBMERCATOR_RESOLUTIONS.length - 1;
+        for (int z = 0; z <= maxZoom; z++) {
+            long tilesAtZoom = 1L << z; // 2^z tiles per dimension
+            TileRange range = TileRange.of(0, 0, tilesAtZoom - 1, tilesAtZoom - 1, z, AxisOrigin.UPPER_LEFT);
+            pyramidBuilder.level(range);
+        }
+
+        TilePyramid pyramid = pyramidBuilder.build();
+
+        // Use GeoWebCache resolutions, scale for tile size
+        double[] resolutions = new double[WEBMERCATOR_RESOLUTIONS.length];
+        Coordinate[] origins = new Coordinate[WEBMERCATOR_RESOLUTIONS.length];
+
+        double scaleFactor = tileSize / 256.0; // Scale resolutions for different tile sizes
+
+        for (int i = 0; i < WEBMERCATOR_RESOLUTIONS.length; i++) {
+            resolutions[i] = WEBMERCATOR_RESOLUTIONS[i] * scaleFactor;
+            // WebMercator origin is top-left corner
+            origins[i] = Coordinate.of(-20037508.342789244, 20037508.342789244);
+        }
+
+        return TileMatrixSet.builder()
+                .tilePyramid(pyramid)
+                .crs("EPSG:3857")
+                .tileSize(tileSize, tileSize)
+                .extent(WORLD3857)
+                .resolutions(resolutions)
+                .origins(origins)
+                .build();
+    }
+
+    private static TileMatrixSet createWebMercatorQuad(int tileSize) {
+        TilePyramid.Builder pyramidBuilder = TilePyramid.builder().axisOrigin(AxisOrigin.UPPER_LEFT);
+
+        int maxZoom = WEBMERCATOR_QUAD_SCALES.length - 1;
+        for (int z = 0; z <= maxZoom; z++) {
+            long tilesAtZoom = 1L << z;
+            TileRange range = TileRange.of(0, 0, tilesAtZoom - 1, tilesAtZoom - 1, z, AxisOrigin.UPPER_LEFT);
+            pyramidBuilder.level(range);
+        }
+
+        TilePyramid pyramid = pyramidBuilder.build();
+
+        // Convert scale denominators to resolutions
+        double[] resolutions = new double[WEBMERCATOR_QUAD_SCALES.length];
+        Coordinate[] origins = new Coordinate[WEBMERCATOR_QUAD_SCALES.length];
+
+        double pixelSizeMeters = 0.00028; // Standard pixel size in meters
+        double scaleFactor = tileSize / 256.0;
+
+        for (int i = 0; i < WEBMERCATOR_QUAD_SCALES.length; i++) {
+            // Resolution = scale_denominator * pixel_size_in_meters
+            resolutions[i] = WEBMERCATOR_QUAD_SCALES[i] * pixelSizeMeters * scaleFactor;
+            origins[i] = Coordinate.of(-20037508.3427892, 20037508.3427892);
+        }
+
+        return TileMatrixSet.builder()
+                .tilePyramid(pyramid)
+                .crs("EPSG:3857")
+                .tileSize(tileSize, tileSize)
+                .extent(WORLD3857_TMS)
+                .resolutions(resolutions)
+                .origins(origins)
+                .build();
+    }
+
+    private static TileMatrixSet createWorldCRS84Quad(int tileSize) {
+        TilePyramid.Builder pyramidBuilder = TilePyramid.builder().axisOrigin(AxisOrigin.UPPER_LEFT);
+
+        int maxZoom = CRS84_QUAD_SCALES.length - 1;
+        for (int z = 0; z <= maxZoom; z++) {
+            long tilesWide = 2L << z; // 2 * 2^z for CRS84
+            long tilesHigh = 1L << z; // 1 * 2^z for CRS84
+            TileRange range = TileRange.of(0, 0, tilesWide - 1, tilesHigh - 1, z, AxisOrigin.UPPER_LEFT);
+            pyramidBuilder.level(range);
+        }
+
+        TilePyramid pyramid = pyramidBuilder.build();
+
+        // Convert scale denominators to resolutions
+        double[] resolutions = new double[CRS84_QUAD_SCALES.length];
+        Coordinate[] origins = new Coordinate[CRS84_QUAD_SCALES.length];
+
+        double pixelSizeMeters = 0.00028;
+        double scaleFactor = tileSize / 256.0;
+
+        for (int i = 0; i < CRS84_QUAD_SCALES.length; i++) {
+            resolutions[i] = CRS84_QUAD_SCALES[i] * pixelSizeMeters * scaleFactor;
+            origins[i] = Coordinate.of(-180.0, 90.0);
+        }
+
+        return TileMatrixSet.builder()
+                .tilePyramid(pyramid)
+                .crs("EPSG:4326")
+                .tileSize(tileSize, tileSize)
+                .extent(WORLD4326)
+                .resolutions(resolutions)
+                .origins(origins)
+                .build();
+    }
+}

--- a/src/tileverse-tilepyramid/src/main/java/io/tileverse/tiling/grid/Extent.java
+++ b/src/tileverse-tilepyramid/src/main/java/io/tileverse/tiling/grid/Extent.java
@@ -1,0 +1,210 @@
+/*
+ * (c) Copyright 2025 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.tiling.grid;
+
+/**
+ * Represents a 2D bounding box extent in map space (CRS coordinates).
+ * This is a simple, GIS-library-agnostic representation that can easily
+ * be converted to/from bounding boxes in various GIS libraries.
+ *
+ * <p>The extent is defined by minimum and maximum coordinate values,
+ * representing a rectangular area in the coordinate reference system.
+ *
+ * @param minX the minimum X coordinate (left edge)
+ * @param minY the minimum Y coordinate (bottom edge)
+ * @param maxX the maximum X coordinate (right edge)
+ * @param maxY the maximum Y coordinate (top edge)
+ * @since 1.0
+ */
+public record Extent(double minX, double minY, double maxX, double maxY) {
+
+    public Extent {
+        if (minX > maxX || minY > maxY) {
+            throw new IllegalArgumentException(
+                    String.format("Invalid extent: min(%.6f,%.6f) must be <= max(%.6f,%.6f)", minX, minY, maxX, maxY));
+        }
+    }
+
+    /**
+     * Creates an extent with the specified bounds.
+     *
+     * @param minX the minimum X coordinate
+     * @param minY the minimum Y coordinate
+     * @param maxX the maximum X coordinate
+     * @param maxY the maximum Y coordinate
+     * @return a new Extent instance
+     * @throws IllegalArgumentException if min > max for any dimension
+     */
+    public static Extent of(double minX, double minY, double maxX, double maxY) {
+        return new Extent(minX, minY, maxX, maxY);
+    }
+
+    /**
+     * Creates an extent from two corner coordinates.
+     * The coordinates don't need to be in min/max order - this method
+     * will determine the correct bounds.
+     *
+     * @param corner1 the first corner coordinate
+     * @param corner2 the second corner coordinate
+     * @return a new Extent instance
+     */
+    public static Extent of(Coordinate corner1, Coordinate corner2) {
+        return new Extent(
+                Math.min(corner1.x(), corner2.x()),
+                Math.min(corner1.y(), corner2.y()),
+                Math.max(corner1.x(), corner2.x()),
+                Math.max(corner1.y(), corner2.y()));
+    }
+
+    /**
+     * Creates an extent centered on a coordinate with the specified width and height.
+     *
+     * @param center the center coordinate
+     * @param width the width of the extent
+     * @param height the height of the extent
+     * @return a new Extent instance
+     * @throws IllegalArgumentException if width or height is negative
+     */
+    public static Extent centered(Coordinate center, double width, double height) {
+        if (width < 0 || height < 0) {
+            throw new IllegalArgumentException("Width and height must be non-negative");
+        }
+        double halfWidth = width / 2.0;
+        double halfHeight = height / 2.0;
+        return new Extent(
+                center.x() - halfWidth, center.y() - halfHeight, center.x() + halfWidth, center.y() + halfHeight);
+    }
+
+    /**
+     * Returns the width of this extent (maxX - minX).
+     *
+     * @return the width
+     */
+    public double width() {
+        return maxX - minX;
+    }
+
+    /**
+     * Returns the height of this extent (maxY - minY).
+     *
+     * @return the height
+     */
+    public double height() {
+        return maxY - minY;
+    }
+
+    /**
+     * Returns the area of this extent (width * height).
+     *
+     * @return the area
+     */
+    public double area() {
+        return width() * height();
+    }
+
+    /**
+     * Returns the center coordinate of this extent.
+     *
+     * @return the center coordinate
+     */
+    public Coordinate center() {
+        return new Coordinate((minX + maxX) / 2.0, (minY + maxY) / 2.0);
+    }
+
+    /**
+     * Returns the minimum coordinate (lower-left corner).
+     *
+     * @return the minimum coordinate
+     */
+    public Coordinate min() {
+        return new Coordinate(minX, minY);
+    }
+
+    /**
+     * Returns the maximum coordinate (upper-right corner).
+     *
+     * @return the maximum coordinate
+     */
+    public Coordinate max() {
+        return new Coordinate(maxX, maxY);
+    }
+
+    /**
+     * Tests whether this extent contains the specified coordinate.
+     *
+     * @param coordinate the coordinate to test
+     * @return true if the coordinate is within this extent (inclusive)
+     */
+    public boolean contains(Coordinate coordinate) {
+        return coordinate.x() >= minX && coordinate.x() <= maxX && coordinate.y() >= minY && coordinate.y() <= maxY;
+    }
+
+    /**
+     * Tests whether this extent intersects with another extent.
+     *
+     * @param other the other extent
+     * @return true if the extents intersect
+     */
+    public boolean intersects(Extent other) {
+        return !(other.maxX < minX || other.minX > maxX || other.maxY < minY || other.minY > maxY);
+    }
+
+    /**
+     * Returns the intersection of this extent with another extent.
+     *
+     * @param other the other extent
+     * @return the intersection extent, or null if they don't intersect
+     */
+    public Extent intersection(Extent other) {
+        if (!intersects(other)) {
+            return null;
+        }
+        return new Extent(
+                Math.max(minX, other.minX),
+                Math.max(minY, other.minY),
+                Math.min(maxX, other.maxX),
+                Math.min(maxY, other.maxY));
+    }
+
+    /**
+     * Returns the union of this extent with another extent.
+     *
+     * @param other the other extent
+     * @return the union extent containing both extents
+     */
+    public Extent union(Extent other) {
+        return new Extent(
+                Math.min(minX, other.minX),
+                Math.min(minY, other.minY),
+                Math.max(maxX, other.maxX),
+                Math.max(maxY, other.maxY));
+    }
+
+    /**
+     * Returns this extent expanded by the specified amounts in all directions.
+     *
+     * @param amount the amount to expand (can be negative to shrink)
+     * @return the expanded extent
+     */
+    public Extent expand(double amount) {
+        return new Extent(minX - amount, minY - amount, maxX + amount, maxY + amount);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Extent(%.6f, %.6f, %.6f, %.6f)", minX, minY, maxX, maxY);
+    }
+}

--- a/src/tileverse-tilepyramid/src/main/java/io/tileverse/tiling/grid/StandardTileMatrixSet.java
+++ b/src/tileverse-tilepyramid/src/main/java/io/tileverse/tiling/grid/StandardTileMatrixSet.java
@@ -1,0 +1,217 @@
+/*
+ * (c) Copyright 2025 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.tiling.grid;
+
+import io.tileverse.tiling.model.TileIndex;
+import io.tileverse.tiling.model.TilePyramid;
+import io.tileverse.tiling.model.TileRange;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Standard implementation of TileMatrixSet that provides coordinate
+ * transformation between tile space and map space using composition with a
+ * TilePyramid.
+ *
+ * <p>
+ * This implementation supports common tiling schemes such as:
+ * <ul>
+ * <li>Web Mercator (EPSG:3857) - Google/OSM style tiling</li>
+ * <li>Geographic (EPSG:4326) - WGS84 longitude/latitude</li>
+ * <li>Custom projected coordinate systems</li>
+ * </ul>
+ *
+ * @since 1.0
+ */
+public record StandardTileMatrixSet(
+        TilePyramid tilePyramid,
+        String crsId,
+        int tileWidth,
+        int tileHeight,
+        Extent extent,
+        double[] resolutions,
+        Coordinate[] origins)
+        implements TileMatrixSet {
+
+    @Override
+    public TilePyramid tilePyramid() {
+        return tilePyramid;
+    }
+
+    @Override
+    public String crsId() {
+        return crsId;
+    }
+
+    @Override
+    public int tileWidth() {
+        return tileWidth;
+    }
+
+    @Override
+    public int tileHeight() {
+        return tileHeight;
+    }
+
+    @Override
+    public Extent extent() {
+        return extent;
+    }
+
+    @Override
+    public double resolution(int zoomLevel) {
+        validateZoomLevel(zoomLevel);
+        return resolutions[zoomLevel];
+    }
+
+    @Override
+    public Coordinate origin(int zoomLevel) {
+        validateZoomLevel(zoomLevel);
+        return origins[zoomLevel];
+    }
+
+    @Override
+    public TileIndex coordinateToTile(Coordinate coordinate, int zoomLevel) {
+        validateZoomLevel(zoomLevel);
+
+        double resolution = resolution(zoomLevel);
+        Coordinate origin = origin(zoomLevel);
+
+        // Calculate tile size in map units
+        double tileMapWidth = tileWidth * resolution;
+        double tileMapHeight = tileHeight * resolution;
+
+        long tileX, tileY;
+
+        // Transform map coordinates to tile coordinates based on axis origin
+        switch (tilePyramid.axisOrigin()) {
+            case LOWER_LEFT -> {
+                tileX = (long) Math.floor((coordinate.x() - origin.x()) / tileMapWidth);
+                tileY = (long) Math.floor((coordinate.y() - origin.y()) / tileMapHeight);
+            }
+            case UPPER_LEFT -> {
+                tileX = (long) Math.floor((coordinate.x() - origin.x()) / tileMapWidth);
+                tileY = (long) Math.floor((origin.y() - coordinate.y()) / tileMapHeight);
+            }
+            case LOWER_RIGHT -> {
+                tileX = (long) Math.floor((origin.x() - coordinate.x()) / tileMapWidth);
+                tileY = (long) Math.floor((coordinate.y() - origin.y()) / tileMapHeight);
+            }
+            case UPPER_RIGHT -> {
+                tileX = (long) Math.floor((origin.x() - coordinate.x()) / tileMapWidth);
+                tileY = (long) Math.floor((origin.y() - coordinate.y()) / tileMapHeight);
+            }
+            default -> throw new IllegalStateException("Unsupported axis origin: " + tilePyramid.axisOrigin());
+        }
+
+        TileIndex tile = TileIndex.of(tileX, tileY, zoomLevel);
+
+        // Clamp to pyramid bounds if outside
+        TileRange levelRange = tilePyramid.tileRange(zoomLevel);
+        if (!levelRange.contains(tile)) {
+            tileX = Math.max(levelRange.minx(), Math.min(levelRange.maxx(), tileX));
+            tileY = Math.max(levelRange.miny(), Math.min(levelRange.maxy(), tileY));
+            tile = TileIndex.of(tileX, tileY, zoomLevel);
+        }
+
+        return tile;
+    }
+
+    @Override
+    public TileRange extentToRange(Extent extent, int zoomLevel) {
+        validateZoomLevel(zoomLevel);
+
+        // Find tiles at the corners of the extent
+        TileIndex minTile = coordinateToTile(extent.min(), zoomLevel);
+        TileIndex maxTile = coordinateToTile(extent.max(), zoomLevel);
+
+        // Create range covering all tiles that intersect the extent
+        return TileRange.of(
+                Math.min(minTile.x(), maxTile.x()),
+                Math.min(minTile.y(), maxTile.y()),
+                Math.max(minTile.x(), maxTile.x()),
+                Math.max(minTile.y(), maxTile.y()),
+                zoomLevel,
+                tilePyramid.axisOrigin());
+    }
+
+    private void validateZoomLevel(int zoomLevel) {
+        if (!tilePyramid.hasZoom(zoomLevel)) {
+            throw new IllegalArgumentException("Zoom level " + zoomLevel + " is not supported by this tile matrix set");
+        }
+    }
+
+    // TileMatrix-based API implementation
+
+    @Override
+    public List<TileMatrix> tileMatrices() {
+        return tilePyramid.levels().stream().map(this::createTileMatrix).toList();
+    }
+
+    @Override
+    public Optional<TileMatrix> tileMatrix(int zoomLevel) {
+        return tilePyramid.level(zoomLevel).map(this::createTileMatrix);
+    }
+
+    @Override
+    public Optional<TileMatrixSet> intersection(Extent mapExtent) {
+        return TileMatrixSetView.intersection(this, mapExtent);
+    }
+
+    @Override
+    public TileMatrixSet subset(int minZoomLevel, int maxZoomLevel) {
+        return TileMatrixSetView.subset(this, minZoomLevel, maxZoomLevel);
+    }
+
+    /**
+     * Creates a TileMatrix from a TileRange and this matrix set's spatial
+     * properties.
+     */
+    private TileMatrix createTileMatrix(TileRange tileRange) {
+        int z = tileRange.zoomLevel();
+
+        // Calculate the extent covered by this tile range
+        Extent matrixExtent = tileRange.extent(origin(z), resolution(z), tileWidth, tileHeight);
+
+        return new TileMatrix(tileRange, resolutions[z], origins[z], matrixExtent, crsId, tileWidth, tileHeight);
+    }
+
+    static TileMatrixSet.Builder toBuilder(TileMatrixSet orig) {
+        TileMatrixSet.Builder builder = new TileMatrixSet.Builder()
+                .tilePyramid(orig.tilePyramid())
+                .crs(orig.crsId())
+                .tileSize(orig.tileWidth(), orig.tileHeight())
+                .extent(orig.extent());
+
+        // For StandardTileMatrixSet records, we can access the arrays directly
+        if (orig instanceof StandardTileMatrixSet std) {
+            return builder.resolutions(std.resolutions()).origins(std.origins());
+        }
+
+        // For other implementations, build arrays from zoom level data
+        int minZoom = orig.minZoomLevel();
+        int maxZoom = orig.maxZoomLevel();
+        double[] resolutions = new double[maxZoom + 1];
+        Coordinate[] origins = new Coordinate[maxZoom + 1];
+
+        for (int z = minZoom; z <= maxZoom; z++) {
+            resolutions[z] = orig.resolution(z);
+            origins[z] = orig.origin(z);
+        }
+
+        return builder.resolutions(resolutions).origins(origins);
+    }
+}

--- a/src/tileverse-tilepyramid/src/main/java/io/tileverse/tiling/grid/Tile.java
+++ b/src/tileverse-tilepyramid/src/main/java/io/tileverse/tiling/grid/Tile.java
@@ -1,0 +1,258 @@
+/*
+ * (c) Copyright 2025 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.tiling.grid;
+
+import io.tileverse.tiling.model.TileIndex;
+
+/**
+ * A tile represents a rectangular region of map data with specific dimensions and spatial extent.
+ * It combines the discrete grid coordinates ({@link TileIndex}) with the spatial properties
+ * needed for rendering and coordinate transformations.
+ *
+ * <p>Key properties:
+ * <ul>
+ * <li><b>Tile Index</b>: The discrete grid coordinates (X, Y, Z)</li>
+ * <li><b>Extent</b>: The map space bounding box covered by this tile</li>
+ * <li><b>Dimensions</b>: The pixel width and height of the tile</li>
+ * <li><b>Resolution</b>: Map units per pixel for this tile</li>
+ * <li><b>CRS</b>: Coordinate reference system identifier</li>
+ * </ul>
+ *
+ * <p>Tiles are immutable value objects that can be used for:
+ * <ul>
+ * <li>Spatial queries and intersection testing</li>
+ * <li>Coordinate transformations between pixel and map space</li>
+ * <li>Tile-based rendering and caching operations</li>
+ * <li>Geometric operations on rectangular tile extents</li>
+ * </ul>
+ *
+ * @param tileIndex the discrete grid coordinates for this tile
+ * @param extent the map space bounding box covered by this tile
+ * @param width the tile width in pixels
+ * @param height the tile height in pixels
+ * @param resolution map units per pixel
+ * @param crsId coordinate reference system identifier
+ *
+ * @since 1.0
+ */
+public record Tile(TileIndex tileIndex, Extent extent, int width, int height, double resolution, String crsId) {
+
+    /**
+     * Compact constructor with validation.
+     */
+    public Tile {
+        if (tileIndex == null) {
+            throw new IllegalArgumentException("tileIndex cannot be null");
+        }
+        if (extent == null) {
+            throw new IllegalArgumentException("extent cannot be null");
+        }
+        if (crsId == null || crsId.trim().isEmpty()) {
+            throw new IllegalArgumentException("crsId cannot be null or empty");
+        }
+        if (width <= 0 || height <= 0) {
+            throw new IllegalArgumentException("tile dimensions must be positive");
+        }
+        if (resolution <= 0) {
+            throw new IllegalArgumentException("resolution must be positive");
+        }
+    }
+
+    /**
+     * Returns the X coordinate of this tile.
+     *
+     * @return the tile X coordinate
+     */
+    public long x() {
+        return tileIndex.x();
+    }
+
+    /**
+     * Returns the Y coordinate of this tile.
+     *
+     * @return the tile Y coordinate
+     */
+    public long y() {
+        return tileIndex.y();
+    }
+
+    /**
+     * Returns the zoom level of this tile.
+     *
+     * @return the tile zoom level
+     */
+    public int z() {
+        return tileIndex.z();
+    }
+
+    /**
+     * Returns true if this tile contains the specified map space coordinate.
+     *
+     * @param coordinate the map space coordinate to test
+     * @return true if the coordinate is within this tile's extent
+     */
+    public boolean contains(Coordinate coordinate) {
+        return extent.contains(coordinate);
+    }
+
+    /**
+     * Returns true if this tile intersects with the given extent.
+     *
+     * @param otherExtent the extent to test for intersection
+     * @return true if this tile intersects with the extent
+     */
+    public boolean intersects(Extent otherExtent) {
+        return extent.intersects(otherExtent);
+    }
+
+    /**
+     * Converts a map space coordinate to pixel coordinates within this tile.
+     * The returned coordinate has its origin at the upper-left corner of the tile,
+     * with X increasing to the right and Y increasing downward.
+     *
+     * @param mapCoordinate the map space coordinate
+     * @return the pixel coordinate within this tile, or null if outside tile bounds
+     */
+    public Coordinate mapToPixel(Coordinate mapCoordinate) {
+        if (!contains(mapCoordinate)) {
+            return null;
+        }
+
+        // Convert map coordinate to pixel coordinate relative to tile's upper-left corner
+        double pixelX = (mapCoordinate.x() - extent.minX()) / resolution;
+        double pixelY = (extent.maxY() - mapCoordinate.y()) / resolution;
+
+        // Clamp to tile bounds
+        pixelX = Math.max(0, Math.min(width - 1, pixelX));
+        pixelY = Math.max(0, Math.min(height - 1, pixelY));
+
+        return Coordinate.of(pixelX, pixelY);
+    }
+
+    /**
+     * Converts a pixel coordinate within this tile to map space coordinates.
+     * The pixel coordinate should have its origin at the upper-left corner of the tile.
+     *
+     * @param pixelCoordinate the pixel coordinate within this tile
+     * @return the corresponding map space coordinate
+     * @throws IllegalArgumentException if pixel coordinate is outside tile bounds
+     */
+    public Coordinate pixelToMap(Coordinate pixelCoordinate) {
+        if (pixelCoordinate.x() < 0
+                || pixelCoordinate.x() >= width
+                || pixelCoordinate.y() < 0
+                || pixelCoordinate.y() >= height) {
+            throw new IllegalArgumentException("Pixel coordinate " + pixelCoordinate + " is outside tile bounds [0,0,"
+                    + width + "," + height + "]");
+        }
+
+        // Convert pixel coordinate to map coordinate
+        double mapX = extent.minX() + pixelCoordinate.x() * resolution;
+        double mapY = extent.maxY() - pixelCoordinate.y() * resolution;
+
+        return Coordinate.of(mapX, mapY);
+    }
+
+    /**
+     * Returns the center coordinate of this tile in map space.
+     *
+     * @return the center coordinate of this tile
+     */
+    public Coordinate center() {
+        return extent.center();
+    }
+
+    /**
+     * Returns the area covered by this tile in map units squared.
+     *
+     * @return the tile area in map units squared
+     */
+    public double area() {
+        return extent.area();
+    }
+
+    /**
+     * Returns a string representation of this tile showing its key properties.
+     *
+     * @return a string representation of this tile
+     */
+    @Override
+    public String toString() {
+        return String.format(
+                "Tile[%s, extent=%s, %dx%d, res=%.3f, %s]", tileIndex, extent, width, height, resolution, crsId);
+    }
+
+    /**
+     * Builder for creating Tile instances.
+     */
+    public static class Builder {
+        private TileIndex tileIndex;
+        private Extent extent;
+        private int width = 256;
+        private int height = 256;
+        private double resolution;
+        private String crsId;
+
+        public Builder tileIndex(TileIndex tileIndex) {
+            this.tileIndex = tileIndex;
+            return this;
+        }
+
+        public Builder tileIndex(long x, long y, int z) {
+            this.tileIndex = TileIndex.of(x, y, z);
+            return this;
+        }
+
+        public Builder extent(Extent extent) {
+            this.extent = extent;
+            return this;
+        }
+
+        public Builder extent(double minX, double minY, double maxX, double maxY) {
+            this.extent = Extent.of(minX, minY, maxX, maxY);
+            return this;
+        }
+
+        public Builder size(int width, int height) {
+            this.width = width;
+            this.height = height;
+            return this;
+        }
+
+        public Builder resolution(double resolution) {
+            this.resolution = resolution;
+            return this;
+        }
+
+        public Builder crs(String crsId) {
+            this.crsId = crsId;
+            return this;
+        }
+
+        public Tile build() {
+            return new Tile(tileIndex, extent, width, height, resolution, crsId);
+        }
+    }
+
+    /**
+     * Creates a new builder for Tile.
+     *
+     * @return a new builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+}

--- a/src/tileverse-tilepyramid/src/main/java/io/tileverse/tiling/grid/TileMatrix.java
+++ b/src/tileverse-tilepyramid/src/main/java/io/tileverse/tiling/grid/TileMatrix.java
@@ -1,0 +1,517 @@
+/*
+ * (c) Copyright 2025 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.tiling.grid;
+
+import static java.util.Objects.requireNonNull;
+
+import io.tileverse.tiling.model.TileIndex;
+import io.tileverse.tiling.model.TileRange;
+import java.util.Optional;
+
+/**
+ * A tile matrix represents a collection of tiles with the same size and properties
+ * placed on a regular grid with no overlapping, within a specific coordinate reference system.
+ *
+ * <p>A tile matrix combines the discrete tile grid ({@link TileRange}) with the spatial
+ * properties needed for coordinate transformations (resolution, origin, extent).
+ * This allows spatial operations to be performed directly on the matrix without
+ * requiring external coordinate arrays.
+ *
+ * <p>Key properties:
+ * <ul>
+ * <li><b>Tile Range</b>: The discrete grid of tiles (X, Y coordinates and zoom level)</li>
+ * <li><b>Resolution</b>: Map units per pixel at this zoom level</li>
+ * <li><b>Origin</b>: Map space coordinate corresponding to tile (0,0)</li>
+ * <li><b>Extent</b>: The map space bounding box covered by this matrix</li>
+ * <li><b>CRS</b>: Coordinate reference system identifier</li>
+ * <li><b>Tile Size</b>: Pixel dimensions of each tile</li>
+ * </ul>
+ *
+ * @param tileRange the discrete tile grid for this matrix
+ * @param resolution map units per pixel
+ * @param origin map space coordinate for tile (0,0)
+ * @param extent map space bounding box covered by this matrix
+ * @param crsId coordinate reference system identifier
+ * @param tileWidth tile width in pixels
+ * @param tileHeight tile height in pixels
+ *
+ * @since 1.0
+ */
+public record TileMatrix(
+        TileRange tileRange,
+        double resolution,
+        Coordinate origin,
+        Extent extent,
+        String crsId,
+        int tileWidth,
+        int tileHeight) {
+
+    /**
+     * Compact constructor with validation.
+     */
+    public TileMatrix {
+        if (tileRange == null) {
+            throw new IllegalArgumentException("tileRange cannot be null");
+        }
+        if (origin == null) {
+            throw new IllegalArgumentException("origin cannot be null");
+        }
+        if (extent == null) {
+            throw new IllegalArgumentException("extent cannot be null");
+        }
+        if (crsId == null || crsId.trim().isEmpty()) {
+            throw new IllegalArgumentException("crsId cannot be null or empty");
+        }
+        if (resolution <= 0) {
+            throw new IllegalArgumentException("resolution must be positive");
+        }
+        if (tileWidth <= 0 || tileHeight <= 0) {
+            throw new IllegalArgumentException("tile dimensions must be positive");
+        }
+    }
+
+    /**
+     * Returns the zoom level for this tile matrix.
+     *
+     * @return the zoom level
+     */
+    public int zoomLevel() {
+        return tileRange.zoomLevel();
+    }
+
+    /**
+     * Returns the tile at the specified index, or empty if not within this matrix.
+     *
+     * @param tileIndex the tile index
+     * @return the tile at the specified index, or empty if not within bounds
+     */
+    public Optional<Tile> tile(TileIndex tileIndex) {
+        return Optional.of(requireNonNull(tileIndex, "tileIndex"))
+                .filter(tileRange::contains)
+                .map(this::buildTile);
+    }
+
+    private Tile buildTile(TileIndex index) {
+        Extent tileExtent = tileExtent(index);
+        return Tile.builder()
+                .tileIndex(index)
+                .extent(tileExtent)
+                .size(tileWidth, tileHeight)
+                .resolution(resolution)
+                .crs(crsId)
+                .build();
+    }
+
+    /**
+     * Returns the tile at the specified coordinates.
+     *
+     * @param x the tile X coordinate
+     * @param y the tile Y coordinate
+     * @return the tile at the specified coordinates, or empty if not within bounds
+     */
+    public Optional<Tile> tile(long x, long y) {
+        return tile(TileIndex.of(x, y, zoomLevel()));
+    }
+
+    /**
+     * Returns the map space extent covered by a specific tile index.
+     *
+     * @param tileIndex the tile index
+     * @return the map space extent of the tile
+     * @throws IllegalArgumentException if the tile is not within this matrix
+     */
+    private Extent tileExtent(TileIndex tileIndex) {
+        if (!tileRange.contains(tileIndex)) {
+            throw new IllegalArgumentException("Tile " + tileIndex + " is not within matrix bounds");
+        }
+
+        // Calculate tile extent based on axis origin
+        double tileMapWidth = tileWidth * resolution;
+        double tileMapHeight = tileHeight * resolution;
+
+        double minX, minY, maxX, maxY;
+
+        // Transform tile coordinates to map coordinates based on axis origin
+        switch (tileRange.axisOrigin()) {
+            case LOWER_LEFT -> {
+                minX = origin.x() + tileIndex.x() * tileMapWidth;
+                minY = origin.y() + tileIndex.y() * tileMapHeight;
+                maxX = minX + tileMapWidth;
+                maxY = minY + tileMapHeight;
+            }
+            case UPPER_LEFT -> {
+                minX = origin.x() + tileIndex.x() * tileMapWidth;
+                maxY = origin.y() - tileIndex.y() * tileMapHeight;
+                maxX = minX + tileMapWidth;
+                minY = maxY - tileMapHeight;
+            }
+            case LOWER_RIGHT -> {
+                maxX = origin.x() - tileIndex.x() * tileMapWidth;
+                minY = origin.y() + tileIndex.y() * tileMapHeight;
+                minX = maxX - tileMapWidth;
+                maxY = minY + tileMapHeight;
+            }
+            case UPPER_RIGHT -> {
+                maxX = origin.x() - tileIndex.x() * tileMapWidth;
+                maxY = origin.y() - tileIndex.y() * tileMapHeight;
+                minX = maxX - tileMapWidth;
+                minY = maxY - tileMapHeight;
+            }
+            default -> throw new IllegalStateException("Unsupported axis origin: " + tileRange.axisOrigin());
+        }
+
+        return Extent.of(minX, minY, maxX, maxY);
+    }
+
+    /**
+     * Converts a map space coordinate to the corresponding tile.
+     * If the coordinate falls outside the matrix extent, returns empty.
+     *
+     * @param coordinate the map space coordinate
+     * @return the tile containing the coordinate, or empty if outside matrix bounds
+     */
+    public Optional<Tile> coordinateToTile(Coordinate coordinate) {
+        // Calculate tile size in map units
+        double tileMapWidth = tileWidth * resolution;
+        double tileMapHeight = tileHeight * resolution;
+
+        long tileX, tileY;
+
+        // Transform map coordinates to tile coordinates based on axis origin
+        switch (tileRange.axisOrigin()) {
+            case LOWER_LEFT -> {
+                tileX = (long) Math.floor((coordinate.x() - origin.x()) / tileMapWidth);
+                tileY = (long) Math.floor((coordinate.y() - origin.y()) / tileMapHeight);
+            }
+            case UPPER_LEFT -> {
+                tileX = (long) Math.floor((coordinate.x() - origin.x()) / tileMapWidth);
+                tileY = (long) Math.floor((origin.y() - coordinate.y()) / tileMapHeight);
+            }
+            case LOWER_RIGHT -> {
+                tileX = (long) Math.floor((origin.x() - coordinate.x()) / tileMapWidth);
+                tileY = (long) Math.floor((coordinate.y() - origin.y()) / tileMapHeight);
+            }
+            case UPPER_RIGHT -> {
+                tileX = (long) Math.floor((origin.x() - coordinate.x()) / tileMapWidth);
+                tileY = (long) Math.floor((origin.y() - coordinate.y()) / tileMapHeight);
+            }
+            default -> throw new IllegalStateException("Unsupported axis origin: " + tileRange.axisOrigin());
+        }
+
+        return tile(TileIndex.of(tileX, tileY, zoomLevel()));
+    }
+
+    /**
+     * Converts a map space extent to the corresponding tile range within this matrix.
+     * The returned range covers all tiles that intersect with the given extent.
+     *
+     * @param mapExtent the map space extent
+     * @return the tile range covering the extent, intersected with matrix bounds
+     */
+    public Optional<TileRange> extentToRange(Extent mapExtent) {
+        // Calculate tile coordinates for corner points without bounds checking
+        double tileMapWidth = tileWidth * resolution;
+        double tileMapHeight = tileHeight * resolution;
+
+        long minTileX, minTileY, maxTileX, maxTileY;
+
+        // Transform map coordinates to tile coordinates based on axis origin
+        Coordinate minCoord = mapExtent.min();
+        Coordinate maxCoord = mapExtent.max();
+
+        switch (tileRange.axisOrigin()) {
+            case LOWER_LEFT -> {
+                minTileX = (long) Math.floor((minCoord.x() - origin.x()) / tileMapWidth);
+                minTileY = (long) Math.floor((minCoord.y() - origin.y()) / tileMapHeight);
+                maxTileX = (long) Math.floor((maxCoord.x() - origin.x()) / tileMapWidth);
+                maxTileY = (long) Math.floor((maxCoord.y() - origin.y()) / tileMapHeight);
+            }
+            case UPPER_LEFT -> {
+                minTileX = (long) Math.floor((minCoord.x() - origin.x()) / tileMapWidth);
+                minTileY = (long) Math.floor((origin.y() - maxCoord.y()) / tileMapHeight); // Note: swapped for Y
+                maxTileX = (long) Math.floor((maxCoord.x() - origin.x()) / tileMapWidth);
+                maxTileY = (long) Math.floor((origin.y() - minCoord.y()) / tileMapHeight); // Note: swapped for Y
+            }
+            case LOWER_RIGHT -> {
+                minTileX = (long) Math.floor((origin.x() - maxCoord.x()) / tileMapWidth); // Note: swapped for X
+                minTileY = (long) Math.floor((minCoord.y() - origin.y()) / tileMapHeight);
+                maxTileX = (long) Math.floor((origin.x() - minCoord.x()) / tileMapWidth); // Note: swapped for X
+                maxTileY = (long) Math.floor((maxCoord.y() - origin.y()) / tileMapHeight);
+            }
+            case UPPER_RIGHT -> {
+                minTileX = (long) Math.floor((origin.x() - maxCoord.x()) / tileMapWidth); // Note: swapped for X
+                minTileY = (long) Math.floor((origin.y() - maxCoord.y()) / tileMapHeight); // Note: swapped for Y
+                maxTileX = (long) Math.floor((origin.x() - minCoord.x()) / tileMapWidth); // Note: swapped for X
+                maxTileY = (long) Math.floor((origin.y() - minCoord.y()) / tileMapHeight); // Note: swapped for Y
+            }
+            default -> throw new IllegalStateException("Unsupported axis origin: " + tileRange.axisOrigin());
+        }
+
+        // Ensure min/max are in correct order
+        long actualMinX = Math.min(minTileX, maxTileX);
+        long actualMinY = Math.min(minTileY, maxTileY);
+        long actualMaxX = Math.max(minTileX, maxTileX);
+        long actualMaxY = Math.max(minTileY, maxTileY);
+
+        TileRange extentRange =
+                TileRange.of(actualMinX, actualMinY, actualMaxX, actualMaxY, zoomLevel(), tileRange.axisOrigin());
+
+        // Intersect with matrix bounds to ensure validity
+        return tileRange.intersection(extentRange);
+    }
+
+    /**
+     * Returns true if this tile matrix contains the specified tile index.
+     *
+     * @param tileIndex the tile index to check
+     * @return true if the matrix contains the tile index
+     * @throws IllegalArgumentException if tileIndex is null
+     */
+    public boolean contains(TileIndex tileIndex) {
+        if (tileIndex == null) {
+            throw new IllegalArgumentException("tileIndex cannot be null");
+        }
+        return tileRange.contains(tileIndex);
+    }
+
+    /**
+     * Returns true if this tile matrix contains the specified tile.
+     *
+     * @param tile the tile to check
+     * @return true if the matrix contains the tile
+     * @throws IllegalArgumentException if tile is null
+     */
+    public boolean contains(Tile tile) {
+        if (tile == null) {
+            throw new IllegalArgumentException("tile cannot be null");
+        }
+        return contains(tile.tileIndex());
+    }
+
+    /**
+     * Returns all tiles in this matrix as a stream.
+     * This provides efficient iteration over all tiles without materializing them all at once.
+     *
+     * @return a stream of all tiles in this matrix
+     */
+    public java.util.stream.Stream<Tile> tiles() {
+        // Create a stream that iterates through all tiles in the range
+        return java.util.stream.Stream.iterate(
+                        tileRange.first(),
+                        tileIndex -> tileRange.next(tileIndex).isPresent(),
+                        tileIndex -> tileRange.next(tileIndex).orElse(null))
+                .map(tileIndex ->
+                        tile(tileIndex).orElseThrow()); // Should never be empty since we're iterating valid indices
+    }
+
+    /**
+     * Returns the number of tiles in this matrix.
+     *
+     * @return the tile count
+     */
+    public long tileCount() {
+        return tileRange.count();
+    }
+
+    /**
+     * Returns the width of this matrix in tiles (X span).
+     *
+     * @return the number of tiles in the X direction
+     */
+    public long spanX() {
+        return tileRange.spanX();
+    }
+
+    /**
+     * Returns the height of this matrix in tiles (Y span).
+     *
+     * @return the number of tiles in the Y direction
+     */
+    public long spanY() {
+        return tileRange.spanY();
+    }
+
+    /**
+     * Returns the first tile in natural traversal order for this axis origin.
+     *
+     * @return the first tile in traversal order
+     */
+    public Tile first() {
+        return tile(tileRange.first()).orElseThrow();
+    }
+
+    /**
+     * Returns the last tile in natural traversal order for this axis origin.
+     *
+     * @return the last tile in traversal order
+     */
+    public Tile last() {
+        return tile(tileRange.last()).orElseThrow();
+    }
+
+    /**
+     * Returns the next tile in natural traversal order after the given tile.
+     *
+     * @param current the current tile
+     * @return the next tile in traversal order, or empty if current is the last tile
+     * @throws IllegalArgumentException if current is null
+     */
+    public Optional<Tile> next(Tile current) {
+        if (current == null) {
+            throw new IllegalArgumentException("current tile cannot be null");
+        }
+        return tileRange.next(current.tileIndex()).flatMap(this::tile);
+    }
+
+    /**
+     * Returns the previous tile in natural traversal order before the given tile.
+     *
+     * @param current the current tile
+     * @return the previous tile in traversal order, or empty if current is the first tile
+     * @throws IllegalArgumentException if current is null
+     */
+    public Optional<Tile> prev(Tile current) {
+        if (current == null) {
+            throw new IllegalArgumentException("current tile cannot be null");
+        }
+        return tileRange.prev(current.tileIndex()).flatMap(this::tile);
+    }
+
+    /**
+     * Returns true if this matrix contains all tiles that are in the given matrix.
+     * This checks if the given matrix's tile range is completely contained within this matrix's range.
+     * Returns false if the other matrix is empty (empty matrix contains no tiles).
+     *
+     * @param other the other tile matrix to check
+     * @return true if this matrix contains all tiles in the other matrix
+     * @throws IllegalArgumentException if other is null or if the matrices have different zoom levels
+     */
+    public boolean contains(TileMatrix other) {
+        if (other == null) {
+            throw new IllegalArgumentException("other matrix cannot be null");
+        }
+        if (other.zoomLevel() != zoomLevel()) {
+            throw new IllegalArgumentException(
+                    "Cannot compare matrices with different zoom levels: " + zoomLevel() + " vs " + other.zoomLevel());
+        }
+        // Check if this range contains the other range by checking boundaries
+        TileRange otherRange = other.tileRange;
+        return tileRange.minx() <= otherRange.minx()
+                && tileRange.miny() <= otherRange.miny()
+                && tileRange.maxx() >= otherRange.maxx()
+                && tileRange.maxy() >= otherRange.maxy();
+    }
+
+    /**
+     * Returns true if this tile matrix intersects with the given extent.
+     *
+     * @param mapExtent the map space extent to check
+     * @return true if the matrix intersects with the extent
+     */
+    public boolean intersects(Extent mapExtent) {
+        return extent.intersects(mapExtent);
+    }
+
+    /**
+     * Returns a new TileMatrix containing only the tiles that intersect with the given extent.
+     * The returned matrix has the same spatial properties but a filtered tile range.
+     *
+     * @param mapExtent the map space extent to intersect with
+     * @return a new TileMatrix containing only intersecting tiles, or empty matrix if no intersection
+     */
+    public Optional<TileMatrix> intersection(Extent mapExtent) {
+        return extentToRange(mapExtent).flatMap(tileRange::intersection).map(this::withTileRange);
+    }
+
+    /**
+     * Creates a new TileMatrix with a different tile range but same spatial properties.
+     * Useful for creating subsets or filtered versions of this matrix.
+     *
+     * @param newRange the new tile range
+     * @return a new TileMatrix with the updated range
+     * @throws IllegalArgumentException if the new range has a different zoom level
+     */
+    public TileMatrix withTileRange(TileRange newRange) {
+        if (requireNonNull(newRange).equals(tileRange)) {
+            return this;
+        }
+
+        if (newRange.zoomLevel() != zoomLevel()) {
+            throw new IllegalArgumentException("New range zoom level " + newRange.zoomLevel()
+                    + " does not match current zoom level " + zoomLevel());
+        }
+        // Calculate new extent based on the new tile range
+        Extent newExtent = newRange.extent(origin, resolution, tileWidth, tileHeight);
+        return new TileMatrix(newRange, resolution, origin, newExtent, crsId, tileWidth, tileHeight);
+    }
+
+    /**
+     * Builder for creating TileMatrix instances.
+     */
+    public static class Builder {
+        private TileRange tileRange;
+        private double resolution;
+        private Coordinate origin;
+        private Extent extent;
+        private String crsId;
+        private int tileWidth = 256;
+        private int tileHeight = 256;
+
+        public Builder tileRange(TileRange tileRange) {
+            this.tileRange = tileRange;
+            return this;
+        }
+
+        public Builder resolution(double resolution) {
+            this.resolution = resolution;
+            return this;
+        }
+
+        public Builder origin(Coordinate origin) {
+            this.origin = origin;
+            return this;
+        }
+
+        public Builder extent(Extent extent) {
+            this.extent = extent;
+            return this;
+        }
+
+        public Builder crs(String crsId) {
+            this.crsId = crsId;
+            return this;
+        }
+
+        public Builder tileSize(int width, int height) {
+            this.tileWidth = width;
+            this.tileHeight = height;
+            return this;
+        }
+
+        public TileMatrix build() {
+            return new TileMatrix(tileRange, resolution, origin, extent, crsId, tileWidth, tileHeight);
+        }
+    }
+
+    /**
+     * Creates a new builder for TileMatrix.
+     *
+     * @return a new builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+}

--- a/src/tileverse-tilepyramid/src/main/java/io/tileverse/tiling/grid/TileMatrixSet.java
+++ b/src/tileverse-tilepyramid/src/main/java/io/tileverse/tiling/grid/TileMatrixSet.java
@@ -1,0 +1,444 @@
+/*
+ * (c) Copyright 2025 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.tiling.grid;
+
+import io.tileverse.tiling.model.TileIndex;
+import io.tileverse.tiling.model.TilePyramid;
+import io.tileverse.tiling.model.TileRange;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * A Tile Matrix Set defines the relationship between a tile pyramid's discrete grid
+ * and a continuous coordinate reference system (CRS). It bridges the gap between
+ * tile space (integer coordinates) and map space (real-world coordinates).
+ *
+ * <p>This implementation is CRS-agnostic and can work with any coordinate system,
+ * making it easy to integrate with various GIS libraries without dependencies.
+ *
+ * <p>Key concepts:
+ * <ul>
+ * <li><b>Tile Space</b>: Discrete grid coordinates (tile X, Y, Z)</li>
+ * <li><b>Map Space</b>: Continuous CRS coordinates (longitude/latitude, projected coordinates, etc.)</li>
+ * <li><b>Origin</b>: The map space coordinate corresponding to tile (0,0) at each zoom level</li>
+ * <li><b>Resolution</b>: Map units per pixel at each zoom level</li>
+ * <li><b>Tile Size</b>: Pixel dimensions of each tile (typically 256x256 or 512x512)</li>
+ * </ul>
+ *
+ * @since 1.0
+ */
+public interface TileMatrixSet {
+
+    /**
+     * Builder for creating StandardTileMatrixSet instances.
+     */
+    class Builder {
+        private TilePyramid tilePyramid;
+        private String crsId;
+        private int tileWidth = 256;
+        private int tileHeight = 256;
+        private Extent extent;
+        private double[] resolutions;
+        private Coordinate[] origins;
+
+        /**
+         * Sets the tile pyramid that defines the discrete grid structure.
+         *
+         * @param tilePyramid the tile pyramid
+         * @return this builder
+         */
+        public Builder tilePyramid(TilePyramid tilePyramid) {
+            this.tilePyramid = tilePyramid;
+            return this;
+        }
+
+        /**
+         * Sets the coordinate reference system identifier.
+         *
+         * @param crsId the CRS identifier (e.g., "EPSG:4326", "EPSG:3857")
+         * @return this builder
+         */
+        public Builder crs(String crsId) {
+            this.crsId = crsId;
+            return this;
+        }
+
+        /**
+         * Sets the tile dimensions in pixels.
+         *
+         * @param width  the tile width in pixels
+         * @param height the tile height in pixels
+         * @return this builder
+         */
+        public Builder tileSize(int width, int height) {
+            this.tileWidth = width;
+            this.tileHeight = height;
+            return this;
+        }
+
+        /**
+         * Sets the map space extent covered by this tile matrix set.
+         *
+         * @param extent the map space extent
+         * @return this builder
+         */
+        public Builder extent(Extent extent) {
+            this.extent = extent;
+            return this;
+        }
+
+        /**
+         * Sets the resolutions for each zoom level. The array length must match the
+         * number of zoom levels in the tile pyramid.
+         *
+         * @param resolutions the resolution array (map units per pixel)
+         * @return this builder
+         */
+        public Builder resolutions(double... resolutions) {
+            this.resolutions = resolutions.clone();
+            return this;
+        }
+
+        /**
+         * Sets the origin coordinates for each zoom level. The array length must match
+         * the number of zoom levels in the tile pyramid.
+         *
+         * @param origins the origin coordinate array
+         * @return this builder
+         */
+        public Builder origins(Coordinate... origins) {
+            this.origins = origins.clone();
+            return this;
+        }
+
+        /**
+         * Sets the zoom level range by subsetting the tile pyramid and adjusting
+         * resolutions/origins. This is a convenience method for creating tile matrix
+         * sets with limited zoom ranges.
+         *
+         * @param minZoom the minimum zoom level (inclusive)
+         * @param maxZoom the maximum zoom level (inclusive)
+         * @return this builder
+         * @throws IllegalStateException if tilePyramid, resolutions, or origins are not
+         *                               set
+         */
+        public Builder zoomRange(int minZoom, int maxZoom) {
+            if (tilePyramid == null) {
+                throw new IllegalStateException("tilePyramid must be set before calling zoomRange()");
+            }
+            if (resolutions == null) {
+                throw new IllegalStateException("resolutions must be set before calling zoomRange()");
+            }
+            if (origins == null) {
+                throw new IllegalStateException("origins must be set before calling zoomRange()");
+            }
+
+            // Validate zoom range is within current arrays
+            if (minZoom < 0 || maxZoom >= resolutions.length || maxZoom >= origins.length) {
+                throw new IllegalArgumentException(
+                        "Zoom range [" + minZoom + ", " + maxZoom + "] is outside available array bounds [0, "
+                                + Math.min(resolutions.length - 1, origins.length - 1) + "]");
+            }
+
+            // Validate all zoom levels in range have valid values
+            for (int z = minZoom; z <= maxZoom; z++) {
+                if (resolutions[z] <= 0) {
+                    throw new IllegalArgumentException("Invalid resolution at zoom level " + z + ": " + resolutions[z]);
+                }
+                if (origins[z] == null) {
+                    throw new IllegalArgumentException("Missing origin at zoom level " + z);
+                }
+            }
+
+            // Create new arrays that maintain direct indexing but sized to the max zoom needed
+            double[] subsetResolutions = new double[maxZoom + 1];
+            Coordinate[] subsetOrigins = new Coordinate[maxZoom + 1];
+
+            // Copy relevant values maintaining direct indexing
+            for (int z = minZoom; z <= maxZoom; z++) {
+                subsetResolutions[z] = resolutions[z];
+                subsetOrigins[z] = origins[z];
+            }
+
+            this.resolutions = subsetResolutions;
+            this.origins = subsetOrigins;
+
+            // Now subset the tile pyramid
+            this.tilePyramid = tilePyramid.subset(minZoom, maxZoom);
+
+            return this;
+        }
+
+        /**
+         * Builds the StandardTileMatrixSet instance.
+         *
+         * @return the configured tile matrix set
+         * @throws IllegalStateException if required properties are not set
+         */
+        public TileMatrixSet build() {
+            if (tilePyramid == null) {
+                throw new IllegalStateException("tilePyramid is required");
+            }
+            if (crsId == null) {
+                throw new IllegalStateException("crsId is required");
+            }
+            if (extent == null) {
+                throw new IllegalStateException("extent is required");
+            }
+            if (resolutions == null) {
+                throw new IllegalStateException("resolutions are required");
+            }
+            if (origins == null) {
+                throw new IllegalStateException("origins are required");
+            }
+
+            // Arrays must be large enough to directly index by zoom level
+            int maxZoom = tilePyramid.maxZoomLevel();
+            int minZoom = tilePyramid.minZoomLevel();
+
+            if (resolutions.length <= maxZoom) {
+                throw new IllegalStateException("resolutions array length (" + resolutions.length
+                        + ") must be greater than max zoom level (" + maxZoom + ")");
+            }
+            if (origins.length <= maxZoom) {
+                throw new IllegalStateException("origins array length (" + origins.length
+                        + ") must be greater than max zoom level (" + maxZoom + ")");
+            }
+
+            // Validate that all required zoom levels have values
+            for (int z = minZoom; z <= maxZoom; z++) {
+                if (resolutions[z] <= 0) {
+                    throw new IllegalStateException("Invalid resolution at zoom level " + z + ": " + resolutions[z]);
+                }
+                if (origins[z] == null) {
+                    throw new IllegalStateException("Missing origin at zoom level " + z);
+                }
+            }
+
+            return new StandardTileMatrixSet(tilePyramid, crsId, tileWidth, tileHeight, extent, resolutions, origins);
+        }
+    }
+
+    /**
+     * Returns the underlying tile pyramid that defines the discrete grid structure.
+     *
+     * @return the tile pyramid
+     */
+    TilePyramid tilePyramid();
+
+    /**
+     * Returns the identifier for the coordinate reference system used by this tile matrix set.
+     * This is typically a CRS code like "EPSG:4326", "EPSG:3857", etc., but can be any
+     * string that uniquely identifies the coordinate system.
+     *
+     * @return the CRS identifier
+     */
+    String crsId();
+
+    /**
+     * Returns the pixel width of tiles in this matrix set.
+     * This is typically 256 or 512 pixels.
+     *
+     * @return the tile width in pixels
+     */
+    int tileWidth();
+
+    /**
+     * Returns the pixel height of tiles in this matrix set.
+     * This is typically 256 or 512 pixels.
+     *
+     * @return the tile height in pixels
+     */
+    int tileHeight();
+
+    /**
+     * Returns the map space extent covered by this tile matrix set.
+     * This defines the bounding box in CRS coordinates that encompasses
+     * all tiles at all zoom levels.
+     *
+     * @return the map space extent
+     */
+    Extent extent();
+
+    /**
+     * Returns the map space resolution (map units per pixel) at the specified zoom level.
+     * Higher zoom levels typically have smaller (more detailed) resolutions.
+     *
+     * @param zoomLevel the zoom level
+     * @return the resolution in map units per pixel
+     * @throws IllegalArgumentException if the zoom level is not supported
+     */
+    double resolution(int zoomLevel);
+
+    /**
+     * Returns the map space origin coordinate for the specified zoom level.
+     * This is the map space coordinate that corresponds to tile (0,0) at that zoom level.
+     * The origin depends on the tile pyramid's axis origin configuration.
+     *
+     * @param zoomLevel the zoom level
+     * @return the origin coordinate in map space
+     * @throws IllegalArgumentException if the zoom level is not supported
+     */
+    Coordinate origin(int zoomLevel);
+
+    /**
+     * Converts a map space coordinate to the corresponding tile index at the specified zoom level.
+     * If the coordinate falls outside the matrix set extent, returns the nearest edge tile.
+     *
+     * @param coordinate the map space coordinate
+     * @param zoomLevel the target zoom level
+     * @return the tile index containing the coordinate
+     * @throws IllegalArgumentException if the zoom level is not supported
+     */
+    TileIndex coordinateToTile(Coordinate coordinate, int zoomLevel);
+
+    /**
+     * Converts a map space extent to the corresponding tile range at the specified zoom level.
+     * The returned range covers all tiles that intersect with the given extent.
+     *
+     * @param extent the map space extent
+     * @param zoomLevel the target zoom level
+     * @return the tile range covering the extent
+     * @throws IllegalArgumentException if the zoom level is not supported
+     */
+    TileRange extentToRange(Extent extent, int zoomLevel);
+
+    // New TileMatrix-based API
+
+    /**
+     * Returns all tile matrices in this set, ordered by zoom level.
+     * Each TileMatrix combines a TileRange with its spatial properties.
+     *
+     * @return the list of tile matrices
+     */
+    List<TileMatrix> tileMatrices();
+
+    /**
+     * Returns the tile matrix for the specified zoom level.
+     *
+     * @param zoomLevel the zoom level
+     * @return the tile matrix for the zoom level, or empty if not present
+     */
+    Optional<TileMatrix> tileMatrix(int zoomLevel);
+
+    /**
+     * Returns the tile matrix for the specified zoom level.
+     * Throws an exception if the zoom level is not present.
+     *
+     * @param zoomLevel the zoom level
+     * @return the tile matrix for the zoom level
+     * @throws IllegalArgumentException if the zoom level is not supported
+     */
+    default TileMatrix getTileMatrix(int zoomLevel) {
+        return tileMatrix(zoomLevel)
+                .orElseThrow(() -> new IllegalArgumentException("Zoom level " + zoomLevel + " not found"));
+    }
+
+    /**
+     * Returns the minimum zoom level in this tile matrix set.
+     *
+     * @return the minimum zoom level
+     */
+    default int minZoomLevel() {
+        return tilePyramid().minZoomLevel();
+    }
+
+    /**
+     * Returns the maximum zoom level in this tile matrix set.
+     *
+     * @return the maximum zoom level
+     */
+    default int maxZoomLevel() {
+        return tilePyramid().maxZoomLevel();
+    }
+
+    /**
+     * Returns true if this tile matrix set contains the specified zoom level.
+     *
+     * @param zoomLevel the zoom level to check
+     * @return true if the zoom level is present
+     */
+    default boolean hasZoomLevel(int zoomLevel) {
+        return tileMatrix(zoomLevel).isPresent();
+    }
+
+    /**
+     * Returns a new TileMatrixSet containing only the tiles that intersect with the given extent.
+     * Each tile matrix in the result is filtered to include only tiles that intersect with the extent.
+     * Empty matrices (with no intersecting tiles) are excluded from the result.
+     *
+     * @param mapExtent the map space extent to intersect with
+     * @return a new TileMatrixSet containing only intersecting tiles, or empty if no tiles intersect at any zoom level
+     */
+    Optional<TileMatrixSet> intersection(Extent mapExtent);
+
+    /**
+     * Returns a TileMatrix for the specified zoom level containing only tiles that intersect
+     * with the given extent. This is a convenience method equivalent to calling
+     * {@code getTileMatrix(zoomLevel).intersection(mapExtent)}.
+     *
+     * @param mapExtent the map space extent to intersect with
+     * @param zoomLevel the zoom level for the tile matrix
+     * @return a TileMatrix containing only intersecting tiles at the specified zoom level, or empty if no tiles intersect
+     */
+    default Optional<TileMatrix> intersection(Extent mapExtent, int zoomLevel) {
+        return getTileMatrix(zoomLevel).intersection(mapExtent);
+    }
+
+    /**
+     * Returns a subset of this tile matrix set containing only the specified zoom level range.
+     * This creates a view that delegates to the original matrix set.
+     *
+     * @param minZoomLevel the minimum zoom level (inclusive)
+     * @param maxZoomLevel the maximum zoom level (inclusive)
+     * @return a new TileMatrixSet containing only the specified zoom levels
+     * @throws IllegalArgumentException if the zoom range is invalid or not supported
+     */
+    TileMatrixSet subset(int minZoomLevel, int maxZoomLevel);
+
+    /**
+     * Returns a subset of this tile matrix set containing tiles that intersect with the given extent
+     * within the specified zoom level range. This combines spatial and zoom filtering.
+     *
+     * @param mapExtent the map space extent to intersect with
+     * @param minZoomLevel the minimum zoom level (inclusive)
+     * @param maxZoomLevel the maximum zoom level (inclusive)
+     * @return a new TileMatrixSet containing only intersecting tiles in the zoom range
+     * @throws IllegalArgumentException if the zoom range is invalid or not supported
+     */
+    default Optional<TileMatrixSet> intersection(Extent mapExtent, int minZoomLevel, int maxZoomLevel) {
+        return subset(minZoomLevel, maxZoomLevel).intersection(mapExtent);
+    }
+
+    /**
+     * Creates a new builder for StandardTileMatrixSet.
+     *
+     * @return a new builder instance
+     */
+    static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Creates a builder pre-populated with this tile matrix set's configuration.
+     * Useful for creating variants with different zoom level ranges.
+     *
+     * @return a builder initialized with this tile matrix set's values
+     */
+    default TileMatrixSet.Builder toBuilder() {
+        return StandardTileMatrixSet.toBuilder(this);
+    }
+}

--- a/src/tileverse-tilepyramid/src/main/java/io/tileverse/tiling/grid/TileMatrixSetView.java
+++ b/src/tileverse-tilepyramid/src/main/java/io/tileverse/tiling/grid/TileMatrixSetView.java
@@ -1,0 +1,275 @@
+/*
+ * (c) Copyright 2025 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.tiling.grid;
+
+import static java.util.Objects.requireNonNull;
+
+import io.tileverse.tiling.model.TilePyramid;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A view-based implementation of TileMatrixSet that delegates to another TileMatrixSet
+ * while applying zoom level and/or spatial filtering. This allows for efficient chaining
+ * of subset and intersection operations without creating new underlying data structures.
+ *
+ * <p>This implementation supports:
+ * <ul>
+ * <li>Zoom level filtering (subset operations)</li>
+ * <li>Spatial filtering (intersection operations)</li>
+ * <li>Chaining of multiple filters</li>
+ * <li>Lazy evaluation of filtered matrices</li>
+ * </ul>
+ *
+ * @since 1.0
+ */
+class TileMatrixSetView implements TileMatrixSet {
+
+    private final TileMatrixSet delegate;
+    private final int minZoomLevel;
+    private final int maxZoomLevel;
+    private final Extent filterExtent;
+
+    // Lazy cached values
+    private volatile List<TileMatrix> cachedMatrices;
+    private volatile TilePyramid cachedPyramid;
+
+    /**
+     * Creates a view with zoom level filtering.
+     */
+    private TileMatrixSetView(TileMatrixSet delegate, int minZoomLevel, int maxZoomLevel, Extent filterExtent) {
+        this.delegate = requireNonNull(delegate);
+        this.minZoomLevel = minZoomLevel;
+        this.maxZoomLevel = maxZoomLevel;
+        this.filterExtent = requireNonNull(filterExtent);
+    }
+
+    /**
+     * Creates a zoom-filtered view of the given tile matrix set.
+     */
+    static TileMatrixSetView subset(TileMatrixSet delegate, int minZoomLevel, int maxZoomLevel) {
+        // Validate zoom range
+        if (minZoomLevel > maxZoomLevel) {
+            throw new IllegalArgumentException(
+                    "minZoomLevel (" + minZoomLevel + ") cannot be greater than maxZoomLevel (" + maxZoomLevel + ")");
+        }
+
+        // If delegate is already a view, we can optimize by combining filters
+        if (delegate instanceof TileMatrixSetView view) {
+            int combinedMinZoom = Math.max(minZoomLevel, view.minZoomLevel);
+            int combinedMaxZoom = Math.min(maxZoomLevel, view.maxZoomLevel);
+
+            if (combinedMinZoom > combinedMaxZoom) {
+                throw new IllegalArgumentException("Zoom range [" + minZoomLevel + ", " + maxZoomLevel
+                        + "] does not intersect with existing filter");
+            }
+
+            return new TileMatrixSetView(view.delegate, combinedMinZoom, combinedMaxZoom, view.filterExtent);
+        }
+
+        return new TileMatrixSetView(delegate, minZoomLevel, maxZoomLevel, delegate.extent());
+    }
+
+    /**
+     * Creates a spatially-filtered view of the given tile matrix set.
+     */
+    static Optional<TileMatrixSet> intersection(TileMatrixSet delegate, Extent mapExtent) {
+        TileMatrixSet ret = null;
+        int minZoom, maxZoom;
+
+        // If delegate is already a view, we can combine filters but preserve zoom levels
+        if (delegate instanceof TileMatrixSetView view) {
+            mapExtent = view.filterExtent.intersection(mapExtent);
+            minZoom = view.minZoomLevel;
+            maxZoom = view.maxZoomLevel;
+            delegate = view.delegate;
+        } else {
+            minZoom = delegate.minZoomLevel();
+            maxZoom = delegate.maxZoomLevel();
+        }
+
+        if (delegate.extent().intersects(mapExtent)) {
+            ret = new TileMatrixSetView(delegate, minZoom, maxZoom, mapExtent);
+        }
+
+        return Optional.ofNullable(ret);
+    }
+
+    @Override
+    public TilePyramid tilePyramid() {
+        if (cachedPyramid == null) {
+            synchronized (this) {
+                if (cachedPyramid == null) {
+                    TilePyramid basePyramid = delegate.tilePyramid();
+
+                    // Apply zoom filtering if different from delegate's range
+                    int delegateMin = delegate.minZoomLevel();
+                    int delegateMax = delegate.maxZoomLevel();
+
+                    if (minZoomLevel != delegateMin || maxZoomLevel != delegateMax) {
+                        int actualMin = Math.max(minZoomLevel, basePyramid.minZoomLevel());
+                        int actualMax = Math.min(maxZoomLevel, basePyramid.maxZoomLevel());
+
+                        if (actualMin <= actualMax) {
+                            basePyramid = basePyramid.subset(actualMin, actualMax);
+                        } else {
+                            // Empty pyramid
+                            basePyramid = TilePyramid.builder()
+                                    .axisOrigin(basePyramid.axisOrigin())
+                                    .build();
+                        }
+                    }
+
+                    // Apply spatial filtering if different from delegate's extent
+                    if (!filterExtent.equals(delegate.extent())) {
+                        TilePyramid.Builder pyramidBuilder =
+                                TilePyramid.builder().axisOrigin(basePyramid.axisOrigin());
+
+                        for (var range : basePyramid.levels()) {
+                            // Get the tile matrix for this zoom level and apply spatial filter
+                            Optional<TileMatrix> matrix = delegate.tileMatrix(range.zoomLevel());
+                            if (matrix.isPresent()) {
+                                TileMatrix filtered =
+                                        matrix.get().intersection(filterExtent).orElse(null);
+                                if (filtered != null) {
+                                    pyramidBuilder.level(filtered.tileRange());
+                                }
+                            }
+                        }
+
+                        basePyramid = pyramidBuilder.build();
+                    }
+
+                    cachedPyramid = basePyramid;
+                }
+            }
+        }
+        return cachedPyramid;
+    }
+
+    @Override
+    public String crsId() {
+        return delegate.crsId();
+    }
+
+    @Override
+    public int tileWidth() {
+        return delegate.tileWidth();
+    }
+
+    @Override
+    public int tileHeight() {
+        return delegate.tileHeight();
+    }
+
+    @Override
+    public Extent extent() {
+        return delegate.extent();
+    }
+
+    @Override
+    public double resolution(int zoomLevel) {
+        validateZoomLevel(zoomLevel);
+        return delegate.resolution(zoomLevel);
+    }
+
+    @Override
+    public Coordinate origin(int zoomLevel) {
+        validateZoomLevel(zoomLevel);
+        return delegate.origin(zoomLevel);
+    }
+
+    @Override
+    public List<TileMatrix> tileMatrices() {
+        if (cachedMatrices == null) {
+            synchronized (this) {
+                if (cachedMatrices == null) {
+                    cachedMatrices = tilePyramid().levels().stream()
+                            .map(range -> {
+                                Optional<TileMatrix> matrix = delegate.tileMatrix(range.zoomLevel());
+                                if (matrix.isPresent()) {
+                                    TileMatrix result = matrix.get();
+                                    // Apply spatial filter if different from delegate's extent
+                                    if (!filterExtent.equals(delegate.extent())) {
+                                        result = result.intersection(filterExtent)
+                                                .orElse(null);
+                                    }
+                                    // The zoom filtering is already handled by tilePyramid()
+                                    return result;
+                                }
+                                return null;
+                            })
+                            .filter(Objects::nonNull)
+                            .toList();
+                }
+            }
+        }
+        return cachedMatrices;
+    }
+
+    @Override
+    public Optional<TileMatrix> tileMatrix(int zoomLevel) {
+        if (!isZoomLevelInRange(zoomLevel)) {
+            return Optional.empty();
+        }
+
+        Optional<TileMatrix> matrix = delegate.tileMatrix(zoomLevel);
+        if (matrix.isPresent() && !filterExtent.equals(delegate.extent())) {
+            return matrix.get().intersection(filterExtent);
+        }
+        return matrix;
+    }
+
+    @Override
+    public Optional<TileMatrixSet> intersection(Extent mapExtent) {
+        return TileMatrixSetView.intersection(this, mapExtent);
+    }
+
+    @Override
+    public TileMatrixSet subset(int minZoomLevel, int maxZoomLevel) {
+        return TileMatrixSetView.subset(this, minZoomLevel, maxZoomLevel);
+    }
+
+    // Delegate abstract methods from TileMatrixSet
+
+    @Override
+    public io.tileverse.tiling.model.TileIndex coordinateToTile(Coordinate coordinate, int zoomLevel) {
+        validateZoomLevel(zoomLevel);
+        return delegate.coordinateToTile(coordinate, zoomLevel);
+    }
+
+    @Override
+    public io.tileverse.tiling.model.TileRange extentToRange(Extent extent, int zoomLevel) {
+        validateZoomLevel(zoomLevel);
+        return delegate.extentToRange(extent, zoomLevel);
+    }
+
+    private void validateZoomLevel(int zoomLevel) {
+        if (!isZoomLevelInRange(zoomLevel)) {
+            throw new IllegalArgumentException(
+                    "Zoom level " + zoomLevel + " is not supported by this tile matrix set view");
+        }
+        if (!delegate.hasZoomLevel(zoomLevel)) {
+            throw new IllegalArgumentException(
+                    "Zoom level " + zoomLevel + " is not supported by the underlying tile matrix set");
+        }
+    }
+
+    private boolean isZoomLevelInRange(int zoomLevel) {
+        return zoomLevel >= minZoomLevel && zoomLevel <= maxZoomLevel;
+    }
+}

--- a/src/tileverse-tilepyramid/src/main/java/io/tileverse/tiling/model/AxisOrigin.java
+++ b/src/tileverse-tilepyramid/src/main/java/io/tileverse/tiling/model/AxisOrigin.java
@@ -1,0 +1,257 @@
+/*
+ * (c) Copyright 2025 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.tiling.model;
+
+import java.util.Optional;
+
+/**
+ * Defines the coordinate system origin for tile pyramids and ranges.
+ * Specifies where the (0,0) coordinate is conceptually positioned,
+ * which affects how traversal and query algorithms interpret coordinates.
+ *
+ * @since 1.0
+ */
+public enum AxisOrigin {
+    /**
+     * Origin at lower-left corner.
+     * Y=0 represents the bottom/south, Y increases upward/northward.
+     * Used by TMS (Tile Map Service) and traditional GIS coordinate systems.
+     *
+     * Visual representation:
+     * <pre>
+     * (0,2) (1,2) (2,2)
+     * (0,1) (1,1) (2,1)
+     * (0,0) (1,0) (2,0)  ← Y=0 at bottom
+     * </pre>
+     */
+    LOWER_LEFT {
+        @Override
+        public Optional<TileIndex> next(TileIndex current, TileRange range) {
+            // Left-to-right: increment X first, then wrap to next row at minx
+            long nextX = current.x() + 1;
+            if (nextX <= range.maxx()) {
+                return Optional.of(TileIndex.of(nextX, current.y(), current.z()));
+            }
+            // Wrap to next row
+            long nextY = current.y() + 1;
+            if (nextY <= range.maxy()) {
+                return Optional.of(TileIndex.of(range.minx(), nextY, current.z()));
+            }
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<TileIndex> prev(TileIndex current, TileRange range) {
+            // Left-to-right reverse: decrement X first, then wrap to prev row at maxx
+            long prevX = current.x() - 1;
+            if (prevX >= range.minx()) {
+                return Optional.of(TileIndex.of(prevX, current.y(), current.z()));
+            }
+            // Wrap to prev row
+            long prevY = current.y() - 1;
+            if (prevY >= range.miny()) {
+                return Optional.of(TileIndex.of(range.maxx(), prevY, current.z()));
+            }
+            return Optional.empty();
+        }
+    },
+
+    /**
+     * Origin at upper-left corner.
+     * Y=0 represents the top/north, Y increases downward/southward.
+     * Used by XYZ/Google/Slippy Map tiles and PMTiles.
+     *
+     * Visual representation:
+     * <pre>
+     * (0,0) (1,0) (2,0)  ← Y=0 at top
+     * (0,1) (1,1) (2,1)
+     * (0,2) (1,2) (2,2)
+     * </pre>
+     */
+    UPPER_LEFT {
+        @Override
+        public Optional<TileIndex> next(TileIndex current, TileRange range) {
+            // Left-to-right: increment X first, then wrap to prev row at minx (Y decreases)
+            long nextX = current.x() + 1;
+            if (nextX <= range.maxx()) {
+                return Optional.of(TileIndex.of(nextX, current.y(), current.z()));
+            }
+            // Wrap to prev row (Y decreases in UPPER_LEFT)
+            long prevY = current.y() - 1;
+            if (prevY >= range.miny()) {
+                return Optional.of(TileIndex.of(range.minx(), prevY, current.z()));
+            }
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<TileIndex> prev(TileIndex current, TileRange range) {
+            // Left-to-right reverse: decrement X first, then wrap to next row at maxx (Y increases)
+            long prevX = current.x() - 1;
+            if (prevX >= range.minx()) {
+                return Optional.of(TileIndex.of(prevX, current.y(), current.z()));
+            }
+            // Wrap to next row (Y increases in UPPER_LEFT reverse)
+            long nextY = current.y() + 1;
+            if (nextY <= range.maxy()) {
+                return Optional.of(TileIndex.of(range.maxx(), nextY, current.z()));
+            }
+            return Optional.empty();
+        }
+    },
+
+    /**
+     * Origin at lower-right corner.
+     * Y=0 represents the bottom/south, Y increases upward/northward.
+     * X=0 represents the right/east, X increases leftward/westward.
+     * Rarely used in practice.
+     *
+     * Visual representation:
+     * <pre>
+     * (2,2) (1,2) (0,2)
+     * (2,1) (1,1) (0,1)
+     * (2,0) (1,0) (0,0)  ← Y=0 at bottom, X=0 at right
+     * </pre>
+     */
+    LOWER_RIGHT {
+        @Override
+        public Optional<TileIndex> next(TileIndex current, TileRange range) {
+            // Right-to-left: decrement X first, then wrap to next row at maxx
+            long prevX = current.x() - 1;
+            if (prevX >= range.minx()) {
+                return Optional.of(TileIndex.of(prevX, current.y(), current.z()));
+            }
+            // Wrap to next row
+            long nextY = current.y() + 1;
+            if (nextY <= range.maxy()) {
+                return Optional.of(TileIndex.of(range.maxx(), nextY, current.z()));
+            }
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<TileIndex> prev(TileIndex current, TileRange range) {
+            // Right-to-left reverse: increment X first, then wrap to prev row at minx
+            long nextX = current.x() + 1;
+            if (nextX <= range.maxx()) {
+                return Optional.of(TileIndex.of(nextX, current.y(), current.z()));
+            }
+            // Wrap to prev row
+            long prevY = current.y() - 1;
+            if (prevY >= range.miny()) {
+                return Optional.of(TileIndex.of(range.minx(), prevY, current.z()));
+            }
+            return Optional.empty();
+        }
+    },
+
+    /**
+     * Origin at upper-right corner.
+     * Y=0 represents the top/north, Y increases downward/southward.
+     * X=0 represents the right/east, X increases leftward/westward.
+     * Rarely used in practice.
+     *
+     * Visual representation:
+     * <pre>
+     * (2,0) (1,0) (0,0)  ← Y=0 at top, X=0 at right
+     * (2,1) (1,1) (0,1)
+     * (2,2) (1,2) (0,2)
+     * </pre>
+     */
+    UPPER_RIGHT {
+        @Override
+        public Optional<TileIndex> next(TileIndex current, TileRange range) {
+            // Right-to-left: decrement X first, then wrap to prev row at maxx (Y decreases)
+            long prevX = current.x() - 1;
+            if (prevX >= range.minx()) {
+                return Optional.of(TileIndex.of(prevX, current.y(), current.z()));
+            }
+            // Wrap to prev row (Y decreases in UPPER_RIGHT)
+            long prevY = current.y() - 1;
+            if (prevY >= range.miny()) {
+                return Optional.of(TileIndex.of(range.maxx(), prevY, current.z()));
+            }
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<TileIndex> prev(TileIndex current, TileRange range) {
+            // Right-to-left reverse: increment X first, then wrap to next row at minx (Y increases)
+            long nextX = current.x() + 1;
+            if (nextX <= range.maxx()) {
+                return Optional.of(TileIndex.of(nextX, current.y(), current.z()));
+            }
+            // Wrap to next row (Y increases in UPPER_RIGHT reverse)
+            long nextY = current.y() + 1;
+            if (nextY <= range.maxy()) {
+                return Optional.of(TileIndex.of(range.minx(), nextY, current.z()));
+            }
+            return Optional.empty();
+        }
+    };
+
+    /**
+     * Returns the next tile in natural traversal order for this axis origin.
+     * Uses row-major ordering adapted for the specific coordinate system.
+     *
+     * @param current the current tile index
+     * @param range the tile range containing the current tile
+     * @return the next tile index, or empty if current is the last tile
+     */
+    public abstract Optional<TileIndex> next(TileIndex current, TileRange range);
+
+    /**
+     * Returns the previous tile in natural traversal order for this axis origin.
+     * Uses row-major ordering adapted for the specific coordinate system in reverse.
+     *
+     * @param current the current tile index
+     * @param range the tile range containing the current tile
+     * @return the previous tile index, or empty if current is the first tile
+     */
+    public abstract Optional<TileIndex> prev(TileIndex current, TileRange range);
+
+    /**
+     * Returns true if this axis origin requires Y-coordinate flipping
+     * when converting to the target axis origin.
+     *
+     * @param target the target axis origin
+     * @return true if Y-coordinate transformation is needed
+     */
+    public boolean needsYFlip(AxisOrigin target) {
+        if (this == target) return false;
+
+        boolean thisIsUpper = (this == UPPER_LEFT || this == UPPER_RIGHT);
+        boolean targetIsUpper = (target == UPPER_LEFT || target == UPPER_RIGHT);
+
+        return thisIsUpper != targetIsUpper;
+    }
+
+    /**
+     * Returns true if this axis origin requires X-coordinate flipping
+     * when converting to the target axis origin.
+     *
+     * @param target the target axis origin
+     * @return true if X-coordinate transformation is needed
+     */
+    public boolean needsXFlip(AxisOrigin target) {
+        if (this == target) return false;
+
+        boolean thisIsRight = (this == LOWER_RIGHT || this == UPPER_RIGHT);
+        boolean targetIsRight = (target == LOWER_RIGHT || target == UPPER_RIGHT);
+
+        return thisIsRight != targetIsRight;
+    }
+}

--- a/src/tileverse-tilepyramid/src/main/java/io/tileverse/tiling/model/AxisOriginView.java
+++ b/src/tileverse-tilepyramid/src/main/java/io/tileverse/tiling/model/AxisOriginView.java
@@ -1,0 +1,130 @@
+/*
+ * (c) Copyright 2025 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.tiling.model;
+
+/**
+ * A view of a TileRange that transforms coordinates to a different axis origin.
+ * Computes transformed coordinates on-demand without storing duplicate data.
+ *
+ * @since 1.0
+ */
+class AxisOriginView implements TileRange {
+
+    private final TileRange source;
+    private final AxisOrigin targetOrigin;
+
+    public AxisOriginView(TileRange source, AxisOrigin targetOrigin) {
+        this.source = source;
+        this.targetOrigin = targetOrigin;
+    }
+
+    @Override
+    public int zoomLevel() {
+        return source.zoomLevel();
+    }
+
+    @Override
+    public long minx() {
+        if (source.axisOrigin().needsXFlip(targetOrigin)) {
+            long tilesPerSide = 1L << zoomLevel();
+            return (tilesPerSide - 1) - source.maxx();
+        }
+        return source.minx();
+    }
+
+    @Override
+    public long miny() {
+        if (source.axisOrigin().needsYFlip(targetOrigin)) {
+            long tilesPerSide = 1L << zoomLevel();
+            return (tilesPerSide - 1) - source.maxy();
+        }
+        return source.miny();
+    }
+
+    @Override
+    public long maxx() {
+        if (source.axisOrigin().needsXFlip(targetOrigin)) {
+            long tilesPerSide = 1L << zoomLevel();
+            return (tilesPerSide - 1) - source.minx();
+        }
+        return source.maxx();
+    }
+
+    @Override
+    public long maxy() {
+        if (source.axisOrigin().needsYFlip(targetOrigin)) {
+            long tilesPerSide = 1L << zoomLevel();
+            return (tilesPerSide - 1) - source.miny();
+        }
+        return source.maxy();
+    }
+
+    @Override
+    public long spanX() {
+        return source.spanX(); // Span doesn't change with axis origin
+    }
+
+    @Override
+    public long spanY() {
+        return source.spanY(); // Span doesn't change with axis origin
+    }
+
+    @Override
+    public long count() {
+        return source.count(); // Count doesn't change with axis origin
+    }
+
+    @Override
+    public long countMetaTiles(int width, int height) {
+        return source.countMetaTiles(width, height); // Meta-tile count doesn't change with axis origin
+    }
+
+    // Note: Corner methods use the default implementations from TileRange interface
+    // which are axis-origin aware and use the switch statements based on axisOrigin()
+
+    @Override
+    public AxisOrigin axisOrigin() {
+        return targetOrigin;
+    }
+
+    @Override
+    public TileRange withAxisOrigin(AxisOrigin newTargetOrigin) {
+        if (targetOrigin == newTargetOrigin) {
+            return this;
+        }
+        // If converting back to source origin, unwrap the view
+        if (source.axisOrigin() == newTargetOrigin) {
+            return source;
+        }
+        // Chain views for multiple transformations
+        return new AxisOriginView(this, newTargetOrigin);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof TileRange other && TileRange.equals(this, other);
+    }
+
+    @Override
+    public int hashCode() {
+        return TileRange.hashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return "AxisOriginView{" + targetOrigin + ", source=" + source + "}";
+    }
+}

--- a/src/tileverse-tilepyramid/src/main/java/io/tileverse/tiling/model/MetaTileIndex.java
+++ b/src/tileverse-tilepyramid/src/main/java/io/tileverse/tiling/model/MetaTileIndex.java
@@ -1,0 +1,77 @@
+/*
+ * (c) Copyright 2025 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.tiling.model;
+
+/**
+ * Represents a meta-tile coordinate - a tile that represents a rectangular group of individual tiles.
+ * A meta-tile is essentially a higher-level tile that contains multiple regular tiles within it.
+ *
+ * @param x the X coordinate of the meta-tile
+ * @param y the Y coordinate of the meta-tile
+ * @param z the zoom level
+ * @param tilesWide width of the meta-tile in individual tiles
+ * @param tilesHigh height of the meta-tile in individual tiles
+ * @since 1.0
+ */
+record MetaTileIndex(long x, long y, int z, int tilesWide, int tilesHigh) implements TileIndex {
+
+    public MetaTileIndex {
+        if (tilesWide <= 0) {
+            throw new IllegalArgumentException("tilesWide must be > 0");
+        }
+        if (tilesHigh <= 0) {
+            throw new IllegalArgumentException("tilesHigh must be > 0");
+        }
+    }
+
+    /**
+     * Factory method to create a MetaTileIndex.
+     *
+     * @param x the X coordinate of the meta-tile
+     * @param y the Y coordinate of the meta-tile
+     * @param z the zoom level
+     * @param tilesWide width of the meta-tile in individual tiles
+     * @param tilesHigh height of the meta-tile in individual tiles
+     * @return a new MetaTileIndex
+     */
+    public static MetaTileIndex of(long x, long y, int z, int tilesWide, int tilesHigh) {
+        return new MetaTileIndex(x, y, z, tilesWide, tilesHigh);
+    }
+
+    /**
+     * Returns the TileRange that represents all individual tiles contained within this meta-tile.
+     * This converts the meta-tile coordinate space back to individual tile coordinate space.
+     * Overrides the default TileIndex.asTileRange() to return the multi-tile range.
+     *
+     * @return a TileRange covering all individual tiles in this meta-tile
+     */
+    @Override
+    public TileRange asTileRange() {
+        long minTileX = x * tilesWide;
+        long minTileY = y * tilesHigh;
+        long maxTileX = minTileX + tilesWide - 1;
+        long maxTileY = minTileY + tilesHigh - 1;
+
+        return TileRange.of(minTileX, minTileY, maxTileX, maxTileY, z);
+    }
+
+    /**
+     * Alias for asTileRange() for backward compatibility.
+     */
+    public TileRange asTiles() {
+        return asTileRange();
+    }
+}

--- a/src/tileverse-tilepyramid/src/main/java/io/tileverse/tiling/model/MetaTileRange.java
+++ b/src/tileverse-tilepyramid/src/main/java/io/tileverse/tiling/model/MetaTileRange.java
@@ -1,0 +1,267 @@
+/*
+ * (c) Copyright 2025 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.tiling.model;
+
+/**
+ * A view of a TileRange that interprets it as meta-tiles.
+ * Each meta-tile represents a rectangular group of individual tiles.
+ * This is a view wrapper that computes meta-tile coordinates on-demand from the source TileRange.
+ *
+ * @since 1.0
+ */
+class MetaTileRange implements TileRange {
+
+    private final TileRange source;
+    private final int tilesWide;
+    private final int tilesHigh;
+
+    private MetaTileRange(TileRange source, int tilesWide, int tilesHigh) {
+        if (tilesWide <= 0) {
+            throw new IllegalArgumentException("tilesWide must be > 0");
+        }
+        if (tilesHigh <= 0) {
+            throw new IllegalArgumentException("tilesHigh must be > 0");
+        }
+        this.source = source;
+        this.tilesWide = tilesWide;
+        this.tilesHigh = tilesHigh;
+    }
+
+    /**
+     * Factory method to create a MetaTileRange view from a source TileRange.
+     *
+     * @param source the source TileRange to view as meta-tiles
+     * @param tilesWide width of each meta-tile in individual tiles
+     * @param tilesHigh height of each meta-tile in individual tiles
+     * @return a MetaTileRange view of the source
+     */
+    public static MetaTileRange of(TileRange source, int tilesWide, int tilesHigh) {
+        return new MetaTileRange(source, tilesWide, tilesHigh);
+    }
+
+    /**
+     * Factory method to create a MetaTileRange from coordinates.
+     * Creates a source TileRange first, then wraps it.
+     *
+     * @param minx minimum X coordinate (inclusive) in meta-tile space
+     * @param miny minimum Y coordinate (inclusive) in meta-tile space
+     * @param maxx maximum X coordinate (inclusive) in meta-tile space
+     * @param maxy maximum Y coordinate (inclusive) in meta-tile space
+     * @param zoomLevel the zoom level
+     * @param tilesWide width of each meta-tile in individual tiles
+     * @param tilesHigh height of each meta-tile in individual tiles
+     * @return a new MetaTileRange with LOWER_LEFT axis origin
+     */
+    public static MetaTileRange of(
+            long minx, long miny, long maxx, long maxy, int zoomLevel, int tilesWide, int tilesHigh) {
+        return of(minx, miny, maxx, maxy, zoomLevel, tilesWide, tilesHigh, AxisOrigin.LOWER_LEFT);
+    }
+
+    /**
+     * Factory method to create a MetaTileRange from coordinates with axis origin.
+     * Creates a source TileRange first, then wraps it.
+     *
+     * @param minx minimum X coordinate (inclusive) in meta-tile space
+     * @param miny minimum Y coordinate (inclusive) in meta-tile space
+     * @param maxx maximum X coordinate (inclusive) in meta-tile space
+     * @param maxy maximum Y coordinate (inclusive) in meta-tile space
+     * @param zoomLevel the zoom level
+     * @param tilesWide width of each meta-tile in individual tiles
+     * @param tilesHigh height of each meta-tile in individual tiles
+     * @param axisOrigin the axis origin
+     * @return a new MetaTileRange
+     */
+    public static MetaTileRange of(
+            long minx,
+            long miny,
+            long maxx,
+            long maxy,
+            int zoomLevel,
+            int tilesWide,
+            int tilesHigh,
+            AxisOrigin axisOrigin) {
+        // Convert meta-tile coordinates to individual tile coordinates
+        long minTileX = minx * tilesWide;
+        long minTileY = miny * tilesHigh;
+        long maxTileX = (maxx + 1) * tilesWide - 1;
+        long maxTileY = (maxy + 1) * tilesHigh - 1;
+
+        TileRange sourceTileRange = TileRange.of(minTileX, minTileY, maxTileX, maxTileY, zoomLevel, axisOrigin);
+        return new MetaTileRange(sourceTileRange, tilesWide, tilesHigh);
+    }
+
+    /**
+     * Returns the source TileRange being viewed as meta-tiles.
+     */
+    public TileRange getSource() {
+        return source;
+    }
+
+    /**
+     * Returns the width of each meta-tile in individual tiles.
+     */
+    public int tilesWide() {
+        return tilesWide;
+    }
+
+    /**
+     * Returns the height of each meta-tile in individual tiles.
+     */
+    public int tilesHigh() {
+        return tilesHigh;
+    }
+
+    @Override
+    public int zoomLevel() {
+        return source.zoomLevel();
+    }
+
+    @Override
+    public long minx() {
+        return source.minx() / tilesWide;
+    }
+
+    @Override
+    public long miny() {
+        return source.miny() / tilesHigh;
+    }
+
+    @Override
+    public long maxx() {
+        return source.maxx() / tilesWide;
+    }
+
+    @Override
+    public long maxy() {
+        return source.maxy() / tilesHigh;
+    }
+
+    @Override
+    public long spanX() {
+        return maxx() - minx() + 1;
+    }
+
+    @Override
+    public long spanY() {
+        return maxy() - miny() + 1;
+    }
+
+    @Override
+    public long count() {
+        return Math.multiplyExact(spanX(), spanY());
+    }
+
+    @Override
+    public long countMetaTiles(int width, int height) {
+        if (width <= 0) throw new IllegalArgumentException("width must be > 0");
+        if (height <= 0) throw new IllegalArgumentException("height must be > 0");
+
+        long metaX = countMetatiles(spanX(), width);
+        long metaY = countMetatiles(spanY(), height);
+        return Math.multiplyExact(metaX, metaY);
+    }
+
+    private long countMetatiles(long ntiles, int metaSize) {
+        long rem = ntiles % metaSize;
+        long metas = ntiles / metaSize;
+        return (rem > 0 ? 1 : 0) + metas;
+    }
+
+    @Override
+    public TileIndex lowerLeft() {
+        return switch (axisOrigin()) {
+            case LOWER_LEFT -> MetaTileIndex.of(minx(), miny(), zoomLevel(), tilesWide, tilesHigh);
+            case UPPER_LEFT -> MetaTileIndex.of(minx(), maxy(), zoomLevel(), tilesWide, tilesHigh);
+            case LOWER_RIGHT -> MetaTileIndex.of(maxx(), miny(), zoomLevel(), tilesWide, tilesHigh);
+            case UPPER_RIGHT -> MetaTileIndex.of(maxx(), maxy(), zoomLevel(), tilesWide, tilesHigh);
+        };
+    }
+
+    @Override
+    public TileIndex upperRight() {
+        return switch (axisOrigin()) {
+            case LOWER_LEFT -> MetaTileIndex.of(maxx(), maxy(), zoomLevel(), tilesWide, tilesHigh);
+            case UPPER_LEFT -> MetaTileIndex.of(maxx(), miny(), zoomLevel(), tilesWide, tilesHigh);
+            case LOWER_RIGHT -> MetaTileIndex.of(minx(), maxy(), zoomLevel(), tilesWide, tilesHigh);
+            case UPPER_RIGHT -> MetaTileIndex.of(minx(), miny(), zoomLevel(), tilesWide, tilesHigh);
+        };
+    }
+
+    @Override
+    public TileIndex lowerRight() {
+        return switch (axisOrigin()) {
+            case LOWER_LEFT -> MetaTileIndex.of(maxx(), miny(), zoomLevel(), tilesWide, tilesHigh);
+            case UPPER_LEFT -> MetaTileIndex.of(maxx(), maxy(), zoomLevel(), tilesWide, tilesHigh);
+            case LOWER_RIGHT -> MetaTileIndex.of(minx(), miny(), zoomLevel(), tilesWide, tilesHigh);
+            case UPPER_RIGHT -> MetaTileIndex.of(minx(), maxy(), zoomLevel(), tilesWide, tilesHigh);
+        };
+    }
+
+    @Override
+    public TileIndex upperLeft() {
+        return switch (axisOrigin()) {
+            case LOWER_LEFT -> MetaTileIndex.of(minx(), maxy(), zoomLevel(), tilesWide, tilesHigh);
+            case UPPER_LEFT -> MetaTileIndex.of(minx(), miny(), zoomLevel(), tilesWide, tilesHigh);
+            case LOWER_RIGHT -> MetaTileIndex.of(maxx(), maxy(), zoomLevel(), tilesWide, tilesHigh);
+            case UPPER_RIGHT -> MetaTileIndex.of(maxx(), miny(), zoomLevel(), tilesWide, tilesHigh);
+        };
+    }
+
+    /**
+     * Returns the equivalent TileRange in individual tile coordinate space.
+     * This simply returns the source TileRange.
+     *
+     * @return the source TileRange representing individual tiles
+     */
+    public TileRange asTileRange() {
+        return source;
+    }
+
+    @Override
+    public boolean isMetaTiled() {
+        return true;
+    }
+
+    @Override
+    public int metaWidth() {
+        return tilesWide;
+    }
+
+    @Override
+    public int metaHeight() {
+        return tilesHigh;
+    }
+
+    @Override
+    public AxisOrigin axisOrigin() {
+        return source.axisOrigin();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof TileRange other && TileRange.equals(this, other);
+    }
+
+    @Override
+    public int hashCode() {
+        return TileRange.hashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return "MetaTileRange{" + tilesWide + "x" + tilesHigh + ", source=" + source + "}";
+    }
+}

--- a/src/tileverse-tilepyramid/src/main/java/io/tileverse/tiling/model/TileIndex.java
+++ b/src/tileverse-tilepyramid/src/main/java/io/tileverse/tiling/model/TileIndex.java
@@ -1,0 +1,194 @@
+/*
+ * (c) Copyright 2025 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.tiling.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Comparator;
+import java.util.function.LongUnaryOperator;
+
+/**
+ * Represents a 3D tile coordinate (x, y, z) combining spatial position with zoom level.
+ * This is an immutable value object that provides coordinate manipulation methods.
+ * Orders tiles by zoom level first, then by 2D coordinates.
+ *
+ * <p>The implementation automatically chooses between memory-optimized variants:
+ * uses 32-bit integers when coordinates fit, falls back to 64-bit longs when needed.
+ *
+ * @since 1.0
+ */
+public sealed interface TileIndex extends Comparable<TileIndex> permits TileIndexInt, TileIndexLong, MetaTileIndex {
+
+    public static final Comparator<TileIndex> COMPARATOR =
+            Comparator.comparingInt(TileIndex::z).thenComparing(TileIndex::x).thenComparing(TileIndex::y);
+
+    /**
+     * Factory method to create a TileIndex with the specified coordinates.
+     * Automatically chooses the most memory-efficient implementation.
+     *
+     * @param x the X coordinate
+     * @param y the Y coordinate
+     * @param z the zoom level
+     * @return a new TileIndex instance
+     */
+    @JsonCreator
+    static TileIndex of(@JsonProperty("x") long x, @JsonProperty("y") long y, @JsonProperty("z") int z) {
+        if (x >= Integer.MIN_VALUE && x <= Integer.MAX_VALUE && y >= Integer.MIN_VALUE && y <= Integer.MAX_VALUE) {
+            return new TileIndexInt((int) x, (int) y, z);
+        }
+        return new TileIndexLong(x, y, z);
+    }
+
+    /**
+     * Returns the X coordinate of this tile.
+     *
+     * @return the X coordinate
+     */
+    long x();
+
+    /**
+     * Returns the Y coordinate of this tile.
+     *
+     * @return the Y coordinate
+     */
+    long y();
+
+    /**
+     * Returns the zoom level of this tile.
+     *
+     * @return the zoom level
+     */
+    int z();
+
+    /**
+     * Creates a new TileIndex shifted by the specified amount in the X direction.
+     *
+     * @param deltaX the amount to shift in the X direction
+     * @return a new TileIndex with the shifted X coordinate
+     */
+    default TileIndex shiftX(long deltaX) {
+        return deltaX == 0 ? this : TileIndex.of(x() + deltaX, y(), z());
+    }
+
+    /**
+     * Creates a new TileIndex shifted by the specified amount in the Y direction.
+     *
+     * @param deltaY the amount to shift in the Y direction
+     * @return a new TileIndex with the shifted Y coordinate
+     */
+    default TileIndex shiftY(long deltaY) {
+        return deltaY == 0 ? this : TileIndex.of(x(), y() + deltaY, z());
+    }
+
+    /**
+     * Creates a new TileIndex with the specified X coordinate, keeping Y and Z unchanged.
+     *
+     * @param newX the new X coordinate
+     * @return a new TileIndex with the specified X coordinate
+     */
+    default TileIndex withX(long newX) {
+        return newX == x() ? this : TileIndex.of(newX, y(), z());
+    }
+
+    /**
+     * Creates a new TileIndex with the specified Y coordinate, keeping X and Z unchanged.
+     *
+     * @param newY the new Y coordinate
+     * @return a new TileIndex with the specified Y coordinate
+     */
+    default TileIndex withY(long newY) {
+        return newY == y() ? this : TileIndex.of(x(), newY, z());
+    }
+
+    /**
+     * Creates a new TileIndex shifted by the specified amounts in both directions.
+     *
+     * @param deltaX the amount to shift in the X direction
+     * @param deltaY the amount to shift in the Y direction
+     * @return a new TileIndex with the shifted coordinates
+     */
+    default TileIndex shiftBy(long deltaX, long deltaY) {
+        return TileIndex.of(x() + deltaX, y() + deltaY, z());
+    }
+
+    /**
+     * Creates a new TileIndex by applying transformation functions to the coordinates.
+     *
+     * @param xfunction function to transform the X coordinate
+     * @param yfunction function to transform the Y coordinate
+     * @return a new TileIndex with the transformed coordinates
+     */
+    default TileIndex shiftBy(LongUnaryOperator xfunction, LongUnaryOperator yfunction) {
+        return TileIndex.of(xfunction.applyAsLong(x()), yfunction.applyAsLong(y()), z());
+    }
+
+    /**
+     * Creates a new TileIndex with a different zoom level but same X,Y coordinates.
+     *
+     * @param newZ the new zoom level
+     * @return a new TileIndex with the specified zoom level
+     */
+    default TileIndex atZoom(int newZ) {
+        return newZ == z() ? this : TileIndex.of(x(), y(), newZ);
+    }
+
+    /**
+     * Returns the TileRange that represents the area covered by this tile.
+     * For regular tiles, this returns a single-tile range.
+     * For meta-tiles, this returns the range of all constituent individual tiles.
+     *
+     * @return a TileRange covering the area represented by this tile
+     */
+    default TileRange asTileRange() {
+        return TileRange.of(x(), y(), x(), y(), z());
+    }
+
+    /**
+     * Compares this tile index with another, ordering by zoom level first, then by 2D coordinates.
+     *
+     * @param o the other tile index to compare with
+     * @return a negative integer, zero, or a positive integer as this tile index is less than,
+     *         equal to, or greater than the specified tile index
+     */
+    @Override
+    default int compareTo(TileIndex o) {
+        return COMPARATOR.compare(this, o);
+    }
+
+    /**
+     * Static helper method for equals implementation.
+     * Ensures consistent equality behavior across different TileIndex implementations.
+     *
+     * @param tile1 the first tile index
+     * @param tile2 the index to compare with
+     * @return true if the objects are equal, false otherwise
+     */
+    static boolean tilesEqual(TileIndex tile1, TileIndex tile2) {
+        if (tile1 == tile2) return true;
+        return tile1.z() == tile2.z() && tile1.x() == tile2.x() && tile1.y() == tile2.y();
+    }
+
+    /**
+     * Static helper method for hashCode implementation.
+     * Ensures consistent hash code behavior across different TileIndex implementations.
+     *
+     * @param tile the tile index to compute hash code for
+     * @return the hash code
+     */
+    static int tilesHashCode(TileIndex tile) {
+        return Long.hashCode(tile.x()) ^ Long.hashCode(tile.y()) ^ Integer.hashCode(tile.z());
+    }
+}

--- a/src/tileverse-tilepyramid/src/main/java/io/tileverse/tiling/model/TileIndexInt.java
+++ b/src/tileverse-tilepyramid/src/main/java/io/tileverse/tiling/model/TileIndexInt.java
@@ -1,0 +1,53 @@
+/*
+ * (c) Copyright 2025 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.tiling.model;
+
+/**
+ * Memory-optimized TileIndex implementation using 32-bit integers for coordinates.
+ * <p>
+ * Used when both X and Y coordinates fit within the int range (-2^31 to 2^31-1).
+ * This saves 8 bytes per instance compared to the long-based implementation.
+ *
+ * @param x the X coordinate (32-bit)
+ * @param y the Y coordinate (32-bit)
+ * @param z the zoom level
+ * @since 1.0
+ */
+record TileIndexInt(int xCoord, int yCoord, int zCoord) implements TileIndex {
+
+    // Implement interface methods using record components
+    public long x() {
+        return xCoord;
+    }
+
+    public long y() {
+        return yCoord;
+    }
+
+    public int z() {
+        return zCoord;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof TileIndex other && TileIndex.tilesEqual(this, other);
+    }
+
+    @Override
+    public int hashCode() {
+        return TileIndex.tilesHashCode(this);
+    }
+}

--- a/src/tileverse-tilepyramid/src/main/java/io/tileverse/tiling/model/TileIndexLong.java
+++ b/src/tileverse-tilepyramid/src/main/java/io/tileverse/tiling/model/TileIndexLong.java
@@ -1,0 +1,53 @@
+/*
+ * (c) Copyright 2025 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.tiling.model;
+
+/**
+ * TileIndex implementation using 64-bit longs for coordinates.
+ * <p>
+ * Used when either X or Y coordinates exceed the int range.
+ * Provides full long precision for very large coordinate values.
+ *
+ * @param x the X coordinate (64-bit)
+ * @param y the Y coordinate (64-bit)
+ * @param z the zoom level
+ * @since 1.0
+ */
+record TileIndexLong(long xCoord, long yCoord, int zCoord) implements TileIndex {
+
+    // Implement interface methods using record components
+    public long x() {
+        return xCoord;
+    }
+
+    public long y() {
+        return yCoord;
+    }
+
+    public int z() {
+        return zCoord;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof TileIndex other && TileIndex.tilesEqual(this, other);
+    }
+
+    @Override
+    public int hashCode() {
+        return TileIndex.tilesHashCode(this);
+    }
+}

--- a/src/tileverse-tilepyramid/src/main/java/io/tileverse/tiling/model/TilePyramid.java
+++ b/src/tileverse-tilepyramid/src/main/java/io/tileverse/tiling/model/TilePyramid.java
@@ -1,0 +1,536 @@
+/*
+ * (c) Copyright 2025 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.tiling.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Abstract base class representing a complete multi-level tile pyramid.
+ * Contains tile range operations and provides pyramid-wide functionality.
+ *
+ * @since 1.0
+ */
+public abstract class TilePyramid {
+
+    private final AxisOrigin axisOrigin;
+
+    /**
+     * Default constructor for backward compatibility.
+     * Uses LOWER_LEFT axis origin.
+     */
+    protected TilePyramid() {
+        this(AxisOrigin.LOWER_LEFT);
+    }
+
+    /**
+     * Constructor with explicit axis origin.
+     *
+     * @param axisOrigin the axis origin for this pyramid
+     */
+    protected TilePyramid(AxisOrigin axisOrigin) {
+        this.axisOrigin = axisOrigin != null ? axisOrigin : AxisOrigin.LOWER_LEFT;
+    }
+
+    /**
+     * Returns the immutable list of tile ranges.
+     *
+     * @return the list of tile ranges, sorted by zoom level
+     */
+    public abstract List<TileRange> levels();
+
+    /**
+     * Returns the axis origin for this pyramid.
+     * All levels in the pyramid use the same axis origin.
+     *
+     * @return the axis origin
+     */
+    public AxisOrigin axisOrigin() {
+        return axisOrigin;
+    }
+
+    /**
+     * Factory method to create an empty TilePyramid.
+     *
+     * @return an empty TilePyramid instance with LOWER_LEFT axis origin
+     */
+    public static TilePyramid empty() {
+        return new TilePyramidImpl(List.of(), AxisOrigin.LOWER_LEFT);
+    }
+
+    /**
+     * Factory method to create an empty TilePyramid with axis origin.
+     *
+     * @param axisOrigin the axis origin
+     * @return an empty TilePyramid instance
+     */
+    public static TilePyramid empty(AxisOrigin axisOrigin) {
+        return new TilePyramidImpl(List.of(), axisOrigin);
+    }
+
+    /**
+     * Factory method to create a TilePyramid from a single TileRange.
+     *
+     * @param range the tile range to create a pyramid from
+     * @return a new TilePyramid containing the specified range with LOWER_LEFT axis origin
+     */
+    public static TilePyramid of(TileRange range) {
+        return new TilePyramidImpl(List.of(range), AxisOrigin.LOWER_LEFT);
+    }
+
+    /**
+     * Factory method to create a TilePyramid from a single TileRange with axis origin.
+     *
+     * @param range the tile range to create a pyramid from
+     * @param axisOrigin the axis origin
+     * @return a new TilePyramid containing the specified range
+     */
+    public static TilePyramid of(TileRange range, AxisOrigin axisOrigin) {
+        return new TilePyramidImpl(List.of(range), axisOrigin);
+    }
+
+    /**
+     * Factory method to create a TilePyramid from a collection of ranges.
+     *
+     * @param ranges the tile ranges to include in the pyramid
+     * @return a new TilePyramid containing the specified ranges with LOWER_LEFT axis origin
+     */
+    public static TilePyramid of(Collection<TileRange> ranges) {
+        return new TilePyramidImpl(ranges, AxisOrigin.LOWER_LEFT);
+    }
+
+    /**
+     * Factory method to create a TilePyramid from a collection of ranges with axis origin.
+     *
+     * @param ranges the tile ranges to include in the pyramid
+     * @param axisOrigin the axis origin
+     * @return a new TilePyramid containing the specified ranges
+     */
+    public static TilePyramid of(Collection<TileRange> ranges, AxisOrigin axisOrigin) {
+        return new TilePyramidImpl(ranges, axisOrigin);
+    }
+
+    /**
+     * Returns true if the pyramid contains no tiles.
+     *
+     * @return true if the pyramid is empty
+     */
+    @JsonIgnore
+    public boolean isEmpty() {
+        return count() == 0;
+    }
+
+    /**
+     * Returns the total number of tiles across all zoom levels in the pyramid.
+     *
+     * @return the total number of tiles in the pyramid
+     * @throws ArithmeticException if the total count would overflow Long.MAX_VALUE
+     */
+    public long count() {
+        return levels().stream().mapToLong(TileRange::count).reduce(0L, Math::addExact);
+    }
+
+    /**
+     * Returns the total number of meta-tiles across all zoom levels.
+     *
+     * @param width width of each meta-tile in tiles
+     * @param height height of each meta-tile in tiles
+     * @return the total number of meta-tiles in the pyramid
+     * @throws ArithmeticException if the total count would overflow Long.MAX_VALUE
+     */
+    public long countMetaTiles(int width, int height) {
+        return levels().stream().mapToLong(r -> r.countMetaTiles(width, height)).reduce(0L, Math::addExact);
+    }
+
+    /**
+     * Returns the minimum zoom level in the pyramid.
+     *
+     * @return the minimum zoom level
+     * @throws java.util.NoSuchElementException if the pyramid is empty
+     */
+    public int minZoomLevel() {
+        List<TileRange> levelsList = levels();
+        if (levelsList.isEmpty()) {
+            throw new java.util.NoSuchElementException("Empty pyramid");
+        }
+        return levelsList.get(0).zoomLevel();
+    }
+
+    /**
+     * Returns the maximum zoom level in the pyramid.
+     *
+     * @return the maximum zoom level
+     * @throws java.util.NoSuchElementException if the pyramid is empty
+     */
+    public int maxZoomLevel() {
+        List<TileRange> levelsList = levels();
+        if (levelsList.isEmpty()) {
+            throw new java.util.NoSuchElementException("Empty pyramid");
+        }
+        return levelsList.get(levelsList.size() - 1).zoomLevel();
+    }
+
+    /**
+     * Returns the tile range for a specific zoom level, if present.
+     *
+     * @param zoomLevel the zoom level to query
+     * @return an Optional containing the TileRange for the specified zoom level, or empty if not present
+     */
+    public Optional<TileRange> level(int zoomLevel) {
+        return levels().stream().filter(r -> r.zoomLevel() == zoomLevel).findFirst();
+    }
+
+    /**
+     * Returns the tile range for a specific zoom level.
+     * Throws an exception if the zoom level is not present.
+     *
+     * @param zoomLevel the zoom level to query
+     * @return the TileRange for the specified zoom level
+     * @throws IllegalArgumentException if the zoom level is not present in this pyramid
+     */
+    public TileRange tileRange(int zoomLevel) {
+        return level(zoomLevel)
+                .orElseThrow(() -> new IllegalArgumentException("Zoom level " + zoomLevel + " not found in pyramid"));
+    }
+
+    /**
+     * Returns true if the pyramid contains the specified zoom level.
+     *
+     * @param zoomLevel the zoom level to check
+     * @return true if the pyramid contains the zoom level
+     */
+    public boolean hasZoom(int zoomLevel) {
+        return level(zoomLevel).isPresent();
+    }
+
+    /**
+     * Returns true if the pyramid contains the specified tile index.
+     * The tile must be at a valid zoom level and within the bounds of that level's range.
+     *
+     * @param tile the tile index to check
+     * @return true if the pyramid contains the tile
+     */
+    public boolean contains(TileIndex tile) {
+        return level(tile.z()).map(range -> range.contains(tile)).orElse(false);
+    }
+
+    /**
+     * Returns true if the pyramid contains the specified tile range.
+     * The range must be at a valid zoom level and be fully contained within that level's bounds.
+     *
+     * @param range the tile range to check
+     * @return true if the pyramid contains the range
+     */
+    public boolean contains(TileRange range) {
+        Optional<TileRange> level = level(range.zoomLevel());
+        if (level.isEmpty()) {
+            return false;
+        }
+        TileRange pyramidRange = level.get();
+        return range.minx() >= pyramidRange.minx()
+                && range.miny() >= pyramidRange.miny()
+                && range.maxx() <= pyramidRange.maxx()
+                && range.maxy() <= pyramidRange.maxy();
+    }
+
+    /**
+     * Returns a meta-tile view of this pyramid where each tile represents a meta-tile.
+     * This is a view operation that projects the same data at a different granularity.
+     *
+     * @param tilesWide width of each meta-tile in tiles
+     * @param tilesHigh height of each meta-tile in tiles
+     * @return a TilePyramid view where each range represents meta-tiles
+     */
+    public TilePyramid asMetaTiles(final int tilesWide, final int tilesHigh) {
+        checkArgument(tilesWide > 0, "width must be > 0");
+        checkArgument(tilesHigh > 0, "height must be > 0");
+
+        return new MetaTileView(this, tilesWide, tilesHigh);
+    }
+
+    /**
+     * Returns an individual tile view of this pyramid where each range represents individual tiles.
+     * This is a view operation that converts meta-tile ranges to individual tile ranges.
+     * For pyramids already containing individual tile ranges, returns the same pyramid.
+     *
+     * @return a TilePyramid view where each range represents individual tiles
+     */
+    public abstract TilePyramid asTiles();
+
+    /**
+     * Creates a subset of the pyramid starting from the specified minimum zoom level.
+     *
+     * @param minZLevel the minimum zoom level (inclusive) for the subset
+     * @return a new TilePyramid containing only the specified zoom levels
+     */
+    public TilePyramid fromLevel(int minZLevel) {
+        return subset(minZLevel, maxZoomLevel());
+    }
+
+    /**
+     * Creates a subset of the pyramid up to the specified maximum zoom level.
+     *
+     * @param maxZLevel the maximum zoom level (inclusive) for the subset
+     * @return a new TilePyramid containing only the specified zoom levels
+     */
+    public TilePyramid toLevel(int maxZLevel) {
+        return subset(minZoomLevel(), maxZLevel);
+    }
+
+    /**
+     * Creates a subset view of the pyramid within the specified zoom level range.
+     *
+     * @param minZLevel the minimum zoom level (inclusive)
+     * @param maxZLevel the maximum zoom level (inclusive)
+     * @return a TilePyramid view containing only the specified zoom level range
+     * @throws IllegalArgumentException if {@code minZLevel < 0} or {@code minZLevel > maxZLevel}
+     */
+    public TilePyramid subset(int minZLevel, int maxZLevel) {
+        if (minZLevel < 0 || minZLevel > maxZLevel)
+            throw new IllegalArgumentException("minZLevel must be >= 0 and <= maxZLevel");
+
+        return new SubsetView(this, minZLevel, maxZLevel);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof TilePyramid other && (other == this || levels().equals(other.levels()));
+    }
+
+    @Override
+    public int hashCode() {
+        return levels().hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "{levels=" + levels() + "}";
+    }
+
+    private static void checkArgument(boolean condition, String message) {
+        if (!condition) throw new IllegalArgumentException(message);
+    }
+
+    /**
+     * Returns a new builder for constructing TilePyramid instances.
+     *
+     * @return a new TilePyramid.Builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder class for constructing TilePyramid instances.
+     */
+    public static class Builder {
+        private final List<TileRange> ranges = new ArrayList<>();
+        private AxisOrigin axisOrigin = AxisOrigin.LOWER_LEFT;
+
+        /**
+         * Adds a tile range to the pyramid.
+         *
+         * @param range the tile range to add
+         * @return this builder
+         */
+        public Builder level(TileRange range) {
+            if (range != null) {
+                ranges.add(range);
+            }
+            return this;
+        }
+
+        /**
+         * Adds multiple tile ranges to the pyramid.
+         *
+         * @param ranges the tile ranges to add
+         * @return this builder
+         */
+        public Builder levels(Collection<TileRange> ranges) {
+            if (ranges != null) {
+                this.ranges.addAll(ranges);
+            }
+            return this;
+        }
+
+        /**
+         * Adds multiple tile ranges to the pyramid.
+         *
+         * @param ranges the tile ranges to add
+         * @return this builder
+         */
+        public Builder levels(TileRange... ranges) {
+            if (ranges != null) {
+                this.ranges.addAll(List.of(ranges));
+            }
+            return this;
+        }
+
+        /**
+         * Sets the axis origin for the pyramid.
+         * All tile ranges will be converted to this axis origin if needed.
+         *
+         * @param axisOrigin the axis origin
+         * @return this builder
+         */
+        public Builder axisOrigin(AxisOrigin axisOrigin) {
+            this.axisOrigin = axisOrigin != null ? axisOrigin : AxisOrigin.LOWER_LEFT;
+            return this;
+        }
+
+        /**
+         * Builds the TilePyramid instance.
+         * All tile ranges are converted to the pyramid's axis origin if needed.
+         *
+         * @return a new TilePyramid
+         * @throws ArithmeticException if the total tile count would overflow Long.MAX_VALUE
+         */
+        public TilePyramid build() {
+            // Convert all ranges to the pyramid's axis origin
+            List<TileRange> convertedRanges = ranges.stream()
+                    .map(range -> range.withAxisOrigin(axisOrigin))
+                    .toList();
+
+            TilePyramid pyramid = new TilePyramidImpl(convertedRanges, axisOrigin);
+            // Trigger overflow check by calling count()
+            pyramid.count();
+            return pyramid;
+        }
+    }
+
+    /**
+     * Standard implementation of TilePyramid that stores tile ranges directly.
+     */
+    private static class TilePyramidImpl extends TilePyramid {
+        private final List<TileRange> levels;
+
+        public TilePyramidImpl(Collection<TileRange> ranges, AxisOrigin axisOrigin) {
+            super(axisOrigin);
+            if (ranges == null) {
+                throw new IllegalArgumentException("ranges cannot be null");
+            }
+            // Create immutable, sorted, distinct list
+            this.levels = ranges.stream().sorted().distinct().toList();
+        }
+
+        @Override
+        public List<TileRange> levels() {
+            return levels;
+        }
+
+        @Override
+        public TilePyramid asTiles() {
+            return this; // TilePyramidImpl already contains individual tiles
+        }
+    }
+
+    /**
+     * A view of the pyramid where each tile represents a meta-tile.
+     * This class lazily converts individual tile ranges to meta-tile ranges.
+     */
+    private static class MetaTileView extends TilePyramid {
+        private final TilePyramid source;
+        private final int tilesWidth;
+        private final int tilesHigh;
+        private List<TileRange> metaLevels; // Lazy initialization
+
+        public MetaTileView(TilePyramid source, int tilesWidth, int tilesHigh) {
+            super(source.axisOrigin());
+            this.source = source;
+            this.tilesWidth = tilesWidth;
+            this.tilesHigh = tilesHigh;
+        }
+
+        @Override
+        public List<TileRange> levels() {
+            if (metaLevels == null) {
+                metaLevels = source.levels().stream()
+                        .map(this::convertToMetaTileRange)
+                        .toList();
+            }
+            return metaLevels;
+        }
+
+        private TileRange convertToMetaTileRange(TileRange tileRange) {
+            return TileRangeTransforms.toMetaTileRange(tileRange, tilesWidth, tilesHigh);
+        }
+
+        @Override
+        public TilePyramid asTiles() {
+            return source.asTiles(); // Recursively unwrap to individual tiles
+        }
+
+        @Override
+        public String toString() {
+            return "MetaTileView{" + tilesWidth + "x" + tilesHigh + ", source=" + source + "}";
+        }
+    }
+
+    /**
+     * A view of the pyramid that filters ranges to a specific zoom level range.
+     * Uses efficient subList() to avoid copying or lazy initialization.
+     */
+    private static class SubsetView extends TilePyramid {
+        private final TilePyramid source;
+        private final int startIndex;
+        private final int endIndex;
+        private final int minZLevel;
+        private final int maxZLevel;
+
+        public SubsetView(TilePyramid source, int minZLevel, int maxZLevel) {
+            super(source.axisOrigin());
+            this.source = source;
+            this.minZLevel = minZLevel;
+            this.maxZLevel = maxZLevel;
+
+            List<TileRange> sourceLevels = source.levels();
+
+            // Find start index (first level >= minZLevel)
+            int start = 0;
+            while (start < sourceLevels.size() && sourceLevels.get(start).zoomLevel() < minZLevel) {
+                start++;
+            }
+
+            // Find end index (last level <= maxZLevel)
+            int end = start;
+            while (end < sourceLevels.size() && sourceLevels.get(end).zoomLevel() <= maxZLevel) {
+                end++;
+            }
+
+            this.startIndex = start;
+            this.endIndex = end;
+        }
+
+        @Override
+        public List<TileRange> levels() {
+            return source.levels().subList(startIndex, endIndex);
+        }
+
+        @Override
+        public TilePyramid asTiles() {
+            // Convert source to individual tiles, then re-apply the same subset bounds
+            return source.asTiles().subset(minZLevel, maxZLevel);
+        }
+
+        @Override
+        public String toString() {
+            return "SubsetView{levels=" + minZLevel + "-" + maxZLevel + ", source=" + source + "}";
+        }
+    }
+}

--- a/src/tileverse-tilepyramid/src/main/java/io/tileverse/tiling/model/TileRange.java
+++ b/src/tileverse-tilepyramid/src/main/java/io/tileverse/tiling/model/TileRange.java
@@ -1,0 +1,614 @@
+/*
+ * (c) Copyright 2025 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.tiling.model;
+
+import static java.util.Objects.requireNonNull;
+
+import io.tileverse.tiling.grid.Coordinate;
+import io.tileverse.tiling.grid.Extent;
+import java.util.Comparator;
+import java.util.Optional;
+
+/**
+ * Represents a rectangular range of tiles at a specific zoom level.
+ * Combines 2D spatial bounds with zoom level information for complete tile range definition.
+ * Provides methods for counting tiles and handling meta-tiles.
+ *
+ * @since 1.0
+ */
+public interface TileRange extends Comparable<TileRange> {
+
+    static final Comparator<TileRange> COMPARATOR =
+            Comparator.comparing(TileRange::min).thenComparing(TileRange::max);
+
+    /**
+     * Returns the zoom level of this tile range.
+     *
+     * @return the zoom level
+     */
+    int zoomLevel();
+
+    /**
+     * Returns the minimum tile coordinates of this range.
+     * Always returns (minx, miny) regardless of axis origin or traversal order.
+     * This is a simple accessor for the range's minimum X and Y values.
+     *
+     * @return the minimum tile coordinates as a TileIndex
+     * @see #first() for traversal start position
+     */
+    default TileIndex min() {
+        return TileIndex.of(minx(), miny(), zoomLevel());
+    }
+
+    /**
+     * Returns the maximum tile coordinates of this range.
+     * Always returns (maxx, maxy) regardless of axis origin or traversal order.
+     * This is a simple accessor for the range's maximum X and Y values.
+     *
+     * @return the maximum tile coordinates as a TileIndex
+     * @see #last() for traversal end position
+     */
+    default TileIndex max() {
+        return TileIndex.of(maxx(), maxy(), zoomLevel());
+    }
+
+    /**
+     * Returns the lower-left corner as a TileIndex.
+     * The actual coordinates depend on the axis origin:
+     * - LOWER_LEFT: (minx, miny)
+     * - UPPER_LEFT: (minx, maxy)
+     * - LOWER_RIGHT: (maxx, miny)
+     * - UPPER_RIGHT: (maxx, maxy)
+     *
+     * @return the lower-left corner tile index
+     */
+    default TileIndex lowerLeft() {
+        return switch (axisOrigin()) {
+            case LOWER_LEFT -> TileIndex.of(minx(), miny(), zoomLevel());
+            case UPPER_LEFT -> TileIndex.of(minx(), maxy(), zoomLevel());
+            case LOWER_RIGHT -> TileIndex.of(maxx(), miny(), zoomLevel());
+            case UPPER_RIGHT -> TileIndex.of(maxx(), maxy(), zoomLevel());
+        };
+    }
+
+    /**
+     * Returns the upper-right corner as a TileIndex.
+     * The actual coordinates depend on the axis origin:
+     * - LOWER_LEFT: (maxx, maxy)
+     * - UPPER_LEFT: (maxx, miny)
+     * - LOWER_RIGHT: (minx, maxy)
+     * - UPPER_RIGHT: (minx, miny)
+     *
+     * @return the upper-right corner tile index
+     */
+    default TileIndex upperRight() {
+        return switch (axisOrigin()) {
+            case LOWER_LEFT -> TileIndex.of(maxx(), maxy(), zoomLevel());
+            case UPPER_LEFT -> TileIndex.of(maxx(), miny(), zoomLevel());
+            case LOWER_RIGHT -> TileIndex.of(minx(), maxy(), zoomLevel());
+            case UPPER_RIGHT -> TileIndex.of(minx(), miny(), zoomLevel());
+        };
+    }
+
+    /**
+     * Returns the lower-right corner as a TileIndex.
+     * The actual coordinates depend on the axis origin:
+     * - LOWER_LEFT: (maxx, miny)
+     * - UPPER_LEFT: (maxx, maxy)
+     * - LOWER_RIGHT: (minx, miny)
+     * - UPPER_RIGHT: (minx, maxy)
+     *
+     * @return the lower-right corner tile index
+     */
+    default TileIndex lowerRight() {
+        return switch (axisOrigin()) {
+            case LOWER_LEFT -> TileIndex.of(maxx(), miny(), zoomLevel());
+            case UPPER_LEFT -> TileIndex.of(maxx(), maxy(), zoomLevel());
+            case LOWER_RIGHT -> TileIndex.of(minx(), miny(), zoomLevel());
+            case UPPER_RIGHT -> TileIndex.of(minx(), maxy(), zoomLevel());
+        };
+    }
+
+    /**
+     * Returns the upper-left corner as a TileIndex.
+     * The actual coordinates depend on the axis origin:
+     * - LOWER_LEFT: (minx, maxy)
+     * - UPPER_LEFT: (minx, miny)
+     * - LOWER_RIGHT: (maxx, maxy)
+     * - UPPER_RIGHT: (maxx, miny)
+     *
+     * @return the upper-left corner tile index
+     */
+    default TileIndex upperLeft() {
+        return switch (axisOrigin()) {
+            case LOWER_LEFT -> TileIndex.of(minx(), maxy(), zoomLevel());
+            case UPPER_LEFT -> TileIndex.of(minx(), miny(), zoomLevel());
+            case LOWER_RIGHT -> TileIndex.of(maxx(), maxy(), zoomLevel());
+            case UPPER_RIGHT -> TileIndex.of(maxx(), miny(), zoomLevel());
+        };
+    }
+
+    /**
+     * Returns the minimum X coordinate of the range.
+     *
+     * @return the minimum X coordinate
+     */
+    long minx();
+
+    /**
+     * Returns the minimum Y coordinate of the range.
+     *
+     * @return the minimum Y coordinate
+     */
+    long miny();
+
+    /**
+     * Returns the maximum X coordinate of the range.
+     *
+     * @return the maximum X coordinate
+     */
+    long maxx();
+
+    /**
+     * Returns the maximum Y coordinate of the range.
+     *
+     * @return the maximum Y coordinate
+     */
+    long maxy();
+
+    /**
+     * Returns the number of tiles spanning the X direction.
+     *
+     * @return the X span (inclusive count)
+     */
+    long spanX();
+
+    /**
+     * Returns the number of tiles spanning the Y direction.
+     *
+     * @return the Y span (inclusive count)
+     */
+    long spanY();
+
+    /**
+     * Returns the total number of tiles in the range.
+     *
+     * @return the total number of tiles in the range
+     */
+    long count();
+
+    /**
+     * Returns the total number of meta-tiles with the specified dimensions.
+     *
+     * @param width width of each meta-tile in tiles
+     * @param height height of each meta-tile in tiles
+     * @return the total number of meta-tiles
+     */
+    long countMetaTiles(int width, int height);
+
+    /**
+     * Converts this tile range to a meta-tile range with the specified tile dimensions.
+     * The resulting TileRange will cover the same or slightly larger tile space
+     * to accommodate partial meta-tiles at the boundaries.
+     *
+     * @param tilesWide width of each meta-tile in individual tiles
+     * @param tilesHigh height of each meta-tile in individual tiles
+     * @return a TileRange representing meta-tiles covering this tile range
+     * @throws IllegalArgumentException if {@code tilesWide} or {@code tilesHigh} is {@code <= 0}
+     */
+    default TileRange asMetaTiles(int tilesWide, int tilesHigh) {
+        return TileRangeTransforms.toMetaTileRange(this, tilesWide, tilesHigh);
+    }
+
+    /**
+     * Converts this tile range to individual tile coordinates.
+     * For regular TileRange, this expands to all individual tiles within the range.
+     * For MetaTileRange, this converts to the equivalent individual tile range.
+     *
+     * @return a TileRange representing individual tiles
+     */
+    default TileRange asTiles() {
+        return TileRangeTransforms.toTileRange(this);
+    }
+
+    /**
+     * Returns true if this tile range represents meta-tiles.
+     * Regular individual tile ranges return false, while meta-tile views return true.
+     *
+     * @return true if this is a meta-tile range, false for individual tiles
+     */
+    default boolean isMetaTiled() {
+        return false;
+    }
+
+    /**
+     * Returns the width of each meta-tile in individual tiles.
+     * For regular TileRange, returns 1 (each "meta-tile" is a single tile).
+     * For MetaTileRange, returns the actual meta-tile width.
+     *
+     * @return the meta-tile width in individual tiles
+     */
+    default int metaWidth() {
+        return 1;
+    }
+
+    /**
+     * Returns the height of each meta-tile in individual tiles.
+     * For regular TileRange, returns 1 (each "meta-tile" is a single tile).
+     * For MetaTileRange, returns the actual meta-tile height.
+     *
+     * @return the meta-tile height in individual tiles
+     */
+    default int metaHeight() {
+        return 1;
+    }
+
+    /**
+     * Returns the first tile in natural traversal order for this axis origin.
+     * This is the logical starting point for row-major iteration, which varies by axis origin:
+     * - LOWER_LEFT: (minx, miny) - bottom-left corner
+     * - UPPER_LEFT: (minx, maxy) - top-left corner
+     * - LOWER_RIGHT: (maxx, miny) - bottom-right corner
+     * - UPPER_RIGHT: (maxx, maxy) - top-right corner
+     *
+     * @return the first tile index in traversal order
+     * @see #min() for minimum tile coordinates
+     */
+    default TileIndex first() {
+        return switch (axisOrigin()) {
+            case LOWER_LEFT -> TileIndex.of(minx(), miny(), zoomLevel());
+            case UPPER_LEFT -> TileIndex.of(minx(), maxy(), zoomLevel()); // Start from top row
+            case LOWER_RIGHT -> TileIndex.of(maxx(), miny(), zoomLevel());
+            case UPPER_RIGHT -> TileIndex.of(maxx(), maxy(), zoomLevel()); // Start from top row
+        };
+    }
+
+    /**
+     * Returns the last tile in natural traversal order for this axis origin.
+     * This is the logical ending point for row-major iteration, which varies by axis origin:
+     * - LOWER_LEFT: (maxx, maxy) - top-right corner
+     * - UPPER_LEFT: (maxx, miny) - bottom-right corner
+     * - LOWER_RIGHT: (minx, maxy) - top-left corner
+     * - UPPER_RIGHT: (minx, miny) - bottom-left corner
+     *
+     * @return the last tile index in traversal order
+     * @see #max() for maximum tile coordinates
+     */
+    default TileIndex last() {
+        return switch (axisOrigin()) {
+            case LOWER_LEFT -> TileIndex.of(maxx(), maxy(), zoomLevel());
+            case UPPER_LEFT -> TileIndex.of(maxx(), miny(), zoomLevel()); // End at bottom row
+            case LOWER_RIGHT -> TileIndex.of(minx(), maxy(), zoomLevel());
+            case UPPER_RIGHT -> TileIndex.of(minx(), miny(), zoomLevel()); // End at bottom row
+        };
+    }
+
+    /**
+     * Returns the next tile in natural traversal order after the given tile.
+     * Uses row-major ordering adapted for the axis origin:
+     * - Increments X first (left-to-right or right-to-left based on axis origin)
+     * - When X reaches boundary, wraps to next row and resets X
+     * - Increments Y in the direction appropriate for axis origin
+     *
+     * @param current the current tile index
+     * @return the next tile index, or empty if current is the last tile or outside range
+     */
+    default Optional<TileIndex> next(TileIndex current) {
+        if (!contains(current)) {
+            return Optional.empty();
+        }
+        return axisOrigin().next(current, this);
+    }
+
+    /**
+     * Returns the previous tile in natural traversal order before the given tile.
+     * Uses row-major ordering adapted for the axis origin in reverse.
+     *
+     * @param current the current tile index
+     * @return the previous tile index, or empty if current is the first tile or outside range
+     */
+    default Optional<TileIndex> prev(TileIndex current) {
+        if (!contains(current)) {
+            return Optional.empty();
+        }
+        return axisOrigin().prev(current, this);
+    }
+
+    /**
+     * Tests whether this tile range contains the given tile index.
+     * The tile must be at the same zoom level and within the coordinate bounds.
+     *
+     * @param tile the tile index to test
+     * @return true if this range contains the tile, false otherwise
+     */
+    default boolean contains(TileIndex tile) {
+        if (tile == null || tile.z() != zoomLevel()) {
+            return false;
+        }
+        long x = tile.x();
+        long y = tile.y();
+        return x >= minx() && x <= maxx() && y >= miny() && y <= maxy();
+    }
+
+    /**
+     * Returns the intersection of this tile range with another tile range.
+     * The intersection contains only tiles that are present in both ranges.
+     * Both ranges must be at the same zoom level.
+     *
+     * @param other the other tile range to intersect with
+     * @return the intersection of the two ranges, or an empty range if no intersection exists
+     * @throws IllegalArgumentException if the ranges are at different zoom levels
+     */
+    default Optional<TileRange> intersection(TileRange other) {
+        requireNonNull(other);
+        if (other.zoomLevel() != zoomLevel()) {
+            throw new IllegalArgumentException(
+                    "Cannot intersect ranges at different zoom levels: " + zoomLevel() + " and " + other.zoomLevel());
+        }
+
+        long minX = Math.max(minx(), other.minx());
+        long minY = Math.max(miny(), other.miny());
+        long maxX = Math.min(maxx(), other.maxx());
+        long maxY = Math.min(maxy(), other.maxy());
+
+        // Ensure the intersection is valid
+        if (minX > maxX || minY > maxY) {
+            // No intersection - return empty range using MAX_VALUE coordinates as a marker
+            return Optional.empty();
+        }
+
+        return Optional.of(TileRange.of(minX, minY, maxX, maxY, zoomLevel(), axisOrigin()));
+    }
+
+    /**
+     * Returns the axis origin for this tile range.
+     * Defines where the (0,0) coordinate is conceptually positioned.
+     *
+     * @return the axis origin, defaults to LOWER_LEFT for backward compatibility
+     */
+    default AxisOrigin axisOrigin() {
+        return AxisOrigin.LOWER_LEFT;
+    }
+
+    /**
+     * Returns a view of this tile range with a different axis origin.
+     * If coordinate transformation is needed, a new view is created that
+     * computes transformed coordinates on-demand.
+     *
+     * @param targetOrigin the target axis origin
+     * @return a TileRange view with the specified axis origin
+     */
+    default TileRange withAxisOrigin(AxisOrigin targetOrigin) {
+        if (this.axisOrigin() == targetOrigin) {
+            return this;
+        }
+        return new AxisOriginView(this, targetOrigin);
+    }
+
+    /**
+     * Compares this tile range with another for ordering.
+     * The natural ordering is:
+     * <ol>
+     * <li>Primary: zoom level (ascending) - lower zoom levels come first</li>
+     * <li>Secondary: minimum X coordinate (ascending)</li>
+     * <li>Tertiary: minimum Y coordinate (ascending)</li>
+     * <li>Quaternary: maximum X coordinate (ascending)</li>
+     * <li>Quinary: maximum Y coordinate (ascending)</li>
+     * </ol>
+     *
+     * This ordering ensures that tile ranges are naturally sorted by zoom level first,
+     * then by spatial position from lower-left to upper-right.
+     *
+     * @param o the tile range to compare with
+     * @return a negative integer, zero, or a positive integer as this range is less than,
+     *         equal to, or greater than the specified range
+     */
+    @Override
+    default int compareTo(TileRange o) {
+        return COMPARATOR.compare(this, o);
+    }
+
+    /**
+     * Calculates the map space extent covered by this tile range.
+     *
+     * @param origin the map space coordinate for tile (0,0)
+     * @param resolution map units per pixel
+     * @param tileWidth tile width in pixels
+     * @param tileHeight tile height in pixels
+     * @return the map space extent covered by this tile range
+     */
+    default Extent extent(Coordinate origin, double resolution, int tileWidth, int tileHeight) {
+        // Calculate tile size in map units
+        double tileMapWidth = tileWidth * resolution;
+        double tileMapHeight = tileHeight * resolution;
+
+        double minExtentX, minExtentY, maxExtentX, maxExtentY;
+
+        // Calculate extents based on axis origin
+        switch (axisOrigin()) {
+            case LOWER_LEFT -> {
+                minExtentX = origin.x() + minx() * tileMapWidth;
+                minExtentY = origin.y() + miny() * tileMapHeight;
+                maxExtentX = origin.x() + (maxx() + 1) * tileMapWidth;
+                maxExtentY = origin.y() + (maxy() + 1) * tileMapHeight;
+            }
+            case UPPER_LEFT -> {
+                minExtentX = origin.x() + minx() * tileMapWidth;
+                maxExtentY = origin.y() - miny() * tileMapHeight;
+                maxExtentX = origin.x() + (maxx() + 1) * tileMapWidth;
+                minExtentY = origin.y() - (maxy() + 1) * tileMapHeight;
+            }
+            case LOWER_RIGHT -> {
+                maxExtentX = origin.x() - minx() * tileMapWidth;
+                minExtentY = origin.y() + miny() * tileMapHeight;
+                minExtentX = origin.x() - (maxx() + 1) * tileMapWidth;
+                maxExtentY = origin.y() + (maxy() + 1) * tileMapHeight;
+            }
+            case UPPER_RIGHT -> {
+                maxExtentX = origin.x() - minx() * tileMapWidth;
+                maxExtentY = origin.y() - miny() * tileMapHeight;
+                minExtentX = origin.x() - (maxx() + 1) * tileMapWidth;
+                minExtentY = origin.y() - (maxy() + 1) * tileMapHeight;
+            }
+            default -> throw new IllegalStateException("Unsupported axis origin: " + axisOrigin());
+        }
+
+        return Extent.of(minExtentX, minExtentY, maxExtentX, maxExtentY);
+    }
+
+    /**
+     * Factory method to create a TileRange from coordinates and zoom level.
+     *
+     * @param minx minimum X coordinate (inclusive)
+     * @param miny minimum Y coordinate (inclusive)
+     * @param maxx maximum X coordinate (inclusive)
+     * @param maxy maximum Y coordinate (inclusive)
+     * @param zoomLevel the zoom level
+     * @return a new TileRange instance with LOWER_LEFT axis origin
+     */
+    static TileRange of(long minx, long miny, long maxx, long maxy, int zoomLevel) {
+        return new TileRangeImpl(minx, miny, maxx, maxy, zoomLevel, AxisOrigin.LOWER_LEFT);
+    }
+
+    /**
+     * Factory method to create a TileRange from coordinates, zoom level and axis origin.
+     *
+     * @param minx minimum X coordinate (inclusive)
+     * @param miny minimum Y coordinate (inclusive)
+     * @param maxx maximum X coordinate (inclusive)
+     * @param maxy maximum Y coordinate (inclusive)
+     * @param zoomLevel the zoom level
+     * @param axisOrigin the axis origin
+     * @return a new TileRange instance
+     */
+    static TileRange of(long minx, long miny, long maxx, long maxy, int zoomLevel, AxisOrigin axisOrigin) {
+        return new TileRangeImpl(minx, miny, maxx, maxy, zoomLevel, axisOrigin);
+    }
+
+    /**
+     * Factory method to create a TileRange from corner indices.
+     * Both tile indices must have the same zoom level.
+     *
+     * @param lowerLeft the lower-left corner tile index
+     * @param upperRight the upper-right corner tile index
+     * @return a new TileRange instance with LOWER_LEFT axis origin
+     * @throws IllegalArgumentException if the tile indices have different zoom levels
+     */
+    static TileRange of(TileIndex lowerLeft, TileIndex upperRight) {
+        if (lowerLeft.z() != upperRight.z()) {
+            throw new IllegalArgumentException("TileIndex arguments must have same zoom level: lowerLeft.z="
+                    + lowerLeft.z() + ", upperRight.z=" + upperRight.z());
+        }
+        return new TileRangeImpl(
+                lowerLeft.x(), lowerLeft.y(), upperRight.x(), upperRight.y(), lowerLeft.z(), AxisOrigin.LOWER_LEFT);
+    }
+
+    /**
+     * Factory method to create a TileRange from minimum and maximum tile coordinates with axis origin.
+     * Both tile indices must have the same zoom level.
+     *
+     * @param minimum the minimum tile coordinates (minx, miny)
+     * @param maximum the maximum tile coordinates (maxx, maxy)
+     * @param axisOrigin the axis origin
+     * @return a new TileRange instance
+     * @throws IllegalArgumentException if the tile indices have different zoom levels
+     */
+    static TileRange of(TileIndex minimum, TileIndex maximum, AxisOrigin axisOrigin) {
+        if (minimum.z() != maximum.z()) {
+            throw new IllegalArgumentException("TileIndex arguments must have same zoom level: minimum.z=" + minimum.z()
+                    + ", maximum.z=" + maximum.z());
+        }
+        return new TileRangeImpl(minimum.x(), minimum.y(), maximum.x(), maximum.y(), minimum.z(), axisOrigin);
+    }
+    /**
+     * Static equals method for TileRange instances.
+     * Two tile ranges are equal if they represent the same tile space.
+     * A MetaTileRange with tilesWide=1 and tilesHigh=1 can be equal to a regular TileRange
+     * with the same coordinates and axis origin, as they represent identical tile spaces.
+     *
+     * @param range1 the first tile range
+     * @param range2 the second tile range
+     * @return true if the tile ranges are equal
+     */
+    static boolean equals(TileRange range1, TileRange range2) {
+        if (range1 == range2) return true;
+        if (range1 == null || range2 == null) return false;
+
+        // Basic coordinate, zoom level, and axis origin equality
+        if (range1.zoomLevel() != range2.zoomLevel()
+                || range1.minx() != range2.minx()
+                || range1.miny() != range2.miny()
+                || range1.maxx() != range2.maxx()
+                || range1.maxy() != range2.maxy()
+                || range1.axisOrigin() != range2.axisOrigin()) {
+            return false;
+        }
+
+        // Same class types are equal if coordinates and axis origin match and (for MetaTileRange) tile dimensions match
+        if (range1.getClass() == range2.getClass()) {
+            // For MetaTileRange, also check tile dimensions
+            if (range1 instanceof MetaTileRange meta1 && range2 instanceof MetaTileRange meta2) {
+                return meta1.tilesWide() == meta2.tilesWide() && meta1.tilesHigh() == meta2.tilesHigh();
+            }
+            return true;
+        }
+
+        // Special case: MetaTileRange with 1x1 tiles equals regular TileRange (same coordinates and axis origin)
+        if (range1 instanceof MetaTileRange meta1 && range2 instanceof TileRange) {
+            return meta1.tilesWide() == 1 && meta1.tilesHigh() == 1;
+        }
+        if (range2 instanceof MetaTileRange meta2 && range1 instanceof TileRange) {
+            return meta2.tilesWide() == 1 && meta2.tilesHigh() == 1;
+        }
+
+        return false;
+    }
+
+    /**
+     * Static hashCode method for TileRange instances.
+     * Computes hash code based on coordinates, zoom level, axis origin, and tile dimensions.
+     * MetaTileRange with 1x1 tiles has the same hash code as regular TileRange with same coordinates and axis origin.
+     *
+     * @param range the tile range
+     * @return the hash code
+     */
+    static int hashCode(TileRange range) {
+        if (range == null) return 0;
+
+        int result;
+        if (range instanceof MetaTileRange meta) {
+            if (meta.tilesWide() == 1 && meta.tilesHigh() == 1) {
+                // 1x1 meta-tiles hash the same as regular tiles
+                result = TileRangeImpl.class.hashCode();
+            } else {
+                // Include tile dimensions in hash for non-1x1 meta-tiles
+                result = MetaTileRange.class.hashCode();
+                result = 31 * result + Integer.hashCode(meta.tilesWide());
+                result = 31 * result + Integer.hashCode(meta.tilesHigh());
+            }
+        } else {
+            result = range.getClass().hashCode();
+        }
+
+        result = 31 * result + Integer.hashCode(range.zoomLevel());
+        result = 31 * result + Long.hashCode(range.minx());
+        result = 31 * result + Long.hashCode(range.miny());
+        result = 31 * result + Long.hashCode(range.maxx());
+        result = 31 * result + Long.hashCode(range.maxy());
+        result = 31 * result + range.axisOrigin().hashCode();
+        return result;
+    }
+}

--- a/src/tileverse-tilepyramid/src/main/java/io/tileverse/tiling/model/TileRangeImpl.java
+++ b/src/tileverse-tilepyramid/src/main/java/io/tileverse/tiling/model/TileRangeImpl.java
@@ -1,0 +1,87 @@
+/*
+ * (c) Copyright 2025 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.tiling.model;
+
+/**
+ * Standard implementation of TileRange representing a rectangular range of individual tiles.
+ *
+ * @param minx minimum X coordinate (inclusive)
+ * @param miny minimum Y coordinate (inclusive)
+ * @param maxx maximum X coordinate (inclusive)
+ * @param maxy maximum Y coordinate (inclusive)
+ * @param zoomLevel the zoom level
+ * @param axisOrigin the axis origin
+ * @since 1.0
+ */
+record TileRangeImpl(long minx, long miny, long maxx, long maxy, int zoomLevel, AxisOrigin axisOrigin)
+        implements TileRange {
+
+    TileRangeImpl {
+        if (minx > maxx || miny > maxy) {
+            throw new IllegalArgumentException(
+                    String.format("Invalid range: min(%d,%d) must be <= max(%d,%d)", minx, miny, maxx, maxy));
+        }
+        if (axisOrigin == null) {
+            throw new IllegalArgumentException("axisOrigin cannot be null");
+        }
+    }
+
+    @Override
+    public long spanX() {
+        return maxx - minx + 1;
+    }
+
+    @Override
+    public long spanY() {
+        return maxy - miny + 1;
+    }
+
+    @Override
+    public long count() {
+        return Math.multiplyExact(spanX(), spanY());
+    }
+
+    @Override
+    public long countMetaTiles(int width, int height) {
+        if (width <= 0) throw new IllegalArgumentException("width must be > 0");
+        if (height <= 0) throw new IllegalArgumentException("height must be > 0");
+
+        long metaX = countMetatiles(spanX(), width);
+        long metaY = countMetatiles(spanY(), height);
+        return Math.multiplyExact(metaX, metaY);
+    }
+
+    @Override
+    public int zoomLevel() {
+        return zoomLevel;
+    }
+
+    private long countMetatiles(long ntiles, int metaSize) {
+        long rem = ntiles % metaSize;
+        long metas = ntiles / metaSize;
+        return (rem > 0 ? 1 : 0) + metas;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof TileRange other && TileRange.equals(this, other);
+    }
+
+    @Override
+    public int hashCode() {
+        return TileRange.hashCode(this);
+    }
+}

--- a/src/tileverse-tilepyramid/src/main/java/io/tileverse/tiling/model/TileRangeTransforms.java
+++ b/src/tileverse-tilepyramid/src/main/java/io/tileverse/tiling/model/TileRangeTransforms.java
@@ -1,0 +1,76 @@
+/*
+ * (c) Copyright 2025 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.tiling.model;
+
+/**
+ * Utility class for transforming between different TileRange representations.
+ * Provides symmetric conversion operations between individual tile ranges and meta-tile ranges.
+ *
+ * @since 1.0
+ */
+final class TileRangeTransforms {
+
+    private TileRangeTransforms() {
+        // Utility class
+    }
+
+    /**
+     * Converts a TileRange to a MetaTileRange view with the specified tile dimensions.
+     * The resulting MetaTileRange will be a view that interprets the source as meta-tiles.
+     *
+     * @param tileRange the tile range to view as meta-tiles
+     * @param tilesWide width of each meta-tile in individual tiles
+     * @param tilesHigh height of each meta-tile in individual tiles
+     * @return a MetaTileRange view of the tile range
+     * @throws IllegalArgumentException if tilesWide or tilesHigh is <= 0
+     */
+    static MetaTileRange toMetaTileRange(TileRange tileRange, int tilesWide, int tilesHigh) {
+        if (tilesWide <= 0) throw new IllegalArgumentException("tilesWide must be > 0");
+        if (tilesHigh <= 0) throw new IllegalArgumentException("tilesHigh must be > 0");
+
+        // If already a MetaTileRange, handle re-tiling
+        if (tileRange instanceof MetaTileRange metaRange) {
+            return convertMetaTileRange(metaRange, tilesWide, tilesHigh);
+        }
+
+        // Create a view of the tile range as meta-tiles
+        return MetaTileRange.of(tileRange, tilesWide, tilesHigh);
+    }
+
+    /**
+     * Converts a TileRange to individual tile coordinates.
+     * For regular TileRange, returns the same range.
+     * For MetaTileRange, returns the underlying source TileRange.
+     *
+     * @param tileRange the tile range to convert
+     * @return a TileRange representing individual tiles
+     */
+    static TileRange toTileRange(TileRange tileRange) {
+        if (tileRange instanceof MetaTileRange metaRange) {
+            return metaRange.getSource(); // Return the wrapped source
+        }
+        return tileRange; // Already individual tiles
+    }
+
+    /**
+     * Converts a MetaTileRange to another MetaTileRange with different tile dimensions.
+     * Uses the source TileRange to create a new view with different meta-tile dimensions.
+     */
+    private static MetaTileRange convertMetaTileRange(MetaTileRange metaRange, int newTilesWide, int newTilesHigh) {
+        // Create a new view of the same source with different tile dimensions
+        return MetaTileRange.of(metaRange.getSource(), newTilesWide, newTilesHigh);
+    }
+}

--- a/src/tileverse-tilepyramid/src/test/java/io/tileverse/tiling/grid/DefaultTileMatrixSetsTest.java
+++ b/src/tileverse-tilepyramid/src/test/java/io/tileverse/tiling/grid/DefaultTileMatrixSetsTest.java
@@ -1,0 +1,320 @@
+/*
+ * (c) Copyright 2025 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.tiling.grid;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.tileverse.tiling.model.AxisOrigin;
+import io.tileverse.tiling.model.TileIndex;
+import io.tileverse.tiling.model.TileRange;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class DefaultTileMatrixSetsTest {
+
+    @Test
+    void testWorldEPSG4326() {
+        TileMatrixSet tms = DefaultTileMatrixSets.WORLD_EPSG4326;
+
+        assertNotNull(tms);
+        assertEquals("EPSG:4326", tms.crsId());
+        assertEquals(256, tms.tileWidth());
+        assertEquals(256, tms.tileHeight());
+        assertEquals(AxisOrigin.UPPER_LEFT, tms.tilePyramid().axisOrigin());
+
+        // EPSG:4326 should have 22 zoom levels (0-21)
+        assertEquals(0, tms.tilePyramid().minZoomLevel());
+        assertEquals(21, tms.tilePyramid().maxZoomLevel());
+        assertEquals(22, tms.tilePyramid().levels().size());
+
+        // Test extent
+        Extent extent = tms.extent();
+        assertEquals(-180.0, extent.minX(), 0.001);
+        assertEquals(-90.0, extent.minY(), 0.001);
+        assertEquals(180.0, extent.maxX(), 0.001);
+        assertEquals(90.0, extent.maxY(), 0.001);
+    }
+
+    @Test
+    void testWorldEPSG4326x2() {
+        TileMatrixSet tms = DefaultTileMatrixSets.WORLD_EPSG4326x2;
+
+        assertEquals("EPSG:4326", tms.crsId());
+        assertEquals(512, tms.tileWidth());
+        assertEquals(512, tms.tileHeight());
+    }
+
+    @Test
+    void testWorldEPSG3857() {
+        TileMatrixSet tms = DefaultTileMatrixSets.WORLD_EPSG3857;
+
+        assertNotNull(tms);
+        assertEquals("EPSG:3857", tms.crsId());
+        assertEquals(256, tms.tileWidth());
+        assertEquals(256, tms.tileHeight());
+        assertEquals(AxisOrigin.UPPER_LEFT, tms.tilePyramid().axisOrigin());
+
+        // Should have 31 zoom levels (0-30) based on WEBMERCATOR_RESOLUTIONS
+        assertEquals(0, tms.tilePyramid().minZoomLevel());
+        assertEquals(30, tms.tilePyramid().maxZoomLevel());
+        assertEquals(31, tms.tilePyramid().levels().size());
+
+        // Test WebMercator extent
+        Extent extent = tms.extent();
+        assertEquals(-20037508.34, extent.minX(), 0.001);
+        assertEquals(-20037508.34, extent.minY(), 0.001);
+        assertEquals(20037508.34, extent.maxX(), 0.001);
+        assertEquals(20037508.34, extent.maxY(), 0.001);
+    }
+
+    @Test
+    void testWebMercatorQuad() {
+        TileMatrixSet tms = DefaultTileMatrixSets.WEB_MERCATOR_QUAD;
+
+        assertNotNull(tms);
+        assertEquals("EPSG:3857", tms.crsId());
+        assertEquals(256, tms.tileWidth());
+        assertEquals(256, tms.tileHeight());
+
+        // Should have 25 zoom levels (0-24) based on WEBMERCATOR_QUAD_SCALES
+        assertEquals(0, tms.tilePyramid().minZoomLevel());
+        assertEquals(24, tms.tilePyramid().maxZoomLevel());
+        assertEquals(25, tms.tilePyramid().levels().size());
+
+        // Test TMS extent (more precise)
+        Extent extent = tms.extent();
+        assertEquals(-20037508.3427892, extent.minX(), 0.001);
+        assertEquals(-20037508.3427892, extent.minY(), 0.001);
+        assertEquals(20037508.3427892, extent.maxX(), 0.001);
+        assertEquals(20037508.3427892, extent.maxY(), 0.001);
+    }
+
+    @Test
+    void testWorldCRS84Quad() {
+        TileMatrixSet tms = DefaultTileMatrixSets.WORLD_CRS84_QUAD;
+
+        assertNotNull(tms);
+        assertEquals("EPSG:4326", tms.crsId());
+        assertEquals(256, tms.tileWidth());
+        assertEquals(256, tms.tileHeight());
+
+        // Should have 18 zoom levels (0-17) based on CRS84_QUAD_SCALES
+        assertEquals(0, tms.tilePyramid().minZoomLevel());
+        assertEquals(17, tms.tilePyramid().maxZoomLevel());
+        assertEquals(18, tms.tilePyramid().levels().size());
+    }
+
+    @Test
+    void testToBuilderAndZoomRange() {
+        TileMatrixSet original = DefaultTileMatrixSets.WEB_MERCATOR_QUAD;
+
+        // Create a subset from zoom 5 to 10
+        TileMatrixSet subset = original.toBuilder().zoomRange(5, 10).build();
+
+        assertNotNull(subset);
+        assertEquals("EPSG:3857", subset.crsId());
+        assertEquals(256, subset.tileWidth());
+        assertEquals(256, subset.tileHeight());
+
+        // Check zoom range
+        assertEquals(5, subset.tilePyramid().minZoomLevel());
+        assertEquals(10, subset.tilePyramid().maxZoomLevel());
+        assertEquals(6, subset.tilePyramid().levels().size()); // 5-10 inclusive = 6 levels
+
+        // Check that resolutions are correctly subset
+        double originalRes5 = original.resolution(5);
+        double subsetRes5 = subset.resolution(5);
+        assertEquals(originalRes5, subsetRes5, 0.001);
+
+        double originalRes10 = original.resolution(10);
+        double subsetRes10 = subset.resolution(10);
+        assertEquals(originalRes10, subsetRes10, 0.001);
+    }
+
+    @Test
+    void testResolutionPyramidStructure() {
+        TileMatrixSet tms = DefaultTileMatrixSets.WEB_MERCATOR_QUAD;
+
+        // Test that each zoom level has the correct number of tiles
+        assertEquals(1, tms.tilePyramid().tileRange(0).count()); // 1x1 = 1 tile
+        assertEquals(4, tms.tilePyramid().tileRange(1).count()); // 2x2 = 4 tiles
+        assertEquals(16, tms.tilePyramid().tileRange(2).count()); // 4x4 = 16 tiles
+
+        // Test that resolutions decrease by half each level
+        double res0 = tms.resolution(0);
+        double res1 = tms.resolution(1);
+        double res2 = tms.resolution(2);
+
+        double ratio1 = res0 / res1;
+        double ratio2 = res1 / res2;
+
+        assertTrue(Math.abs(ratio1 - 2.0) < 0.1, "Resolution ratio should be close to 2.0");
+        assertTrue(Math.abs(ratio2 - 2.0) < 0.1, "Resolution ratio should be close to 2.0");
+    }
+
+    @Test
+    void testTileMatrixAPI() {
+        TileMatrixSet tms = DefaultTileMatrixSets.WEB_MERCATOR_QUAD;
+
+        // Test tileMatrices() method
+        var matrices = tms.tileMatrices();
+        assertNotNull(matrices);
+        assertEquals(25, matrices.size()); // WEB_MERCATOR_QUAD has 25 levels (0-24)
+
+        // Test tileMatrix(int) method
+        var matrix5 = tms.tileMatrix(5);
+        assertTrue(matrix5.isPresent());
+        assertEquals(5, matrix5.get().zoomLevel());
+        assertEquals("EPSG:3857", matrix5.get().crsId());
+        assertEquals(256, matrix5.get().tileWidth());
+
+        // Test getTileMatrix(int) method
+        TileMatrix matrix10 = tms.getTileMatrix(10);
+        assertEquals(10, matrix10.zoomLevel());
+
+        // Test with invalid zoom level
+        assertTrue(tms.tileMatrix(50).isEmpty());
+        assertThrows(IllegalArgumentException.class, () -> {
+            tms.getTileMatrix(50);
+        });
+
+        // Test spatial operations on TileMatrix
+        TileMatrix matrix0 = tms.getTileMatrix(0);
+
+        // At zoom 0, there should be 1 tile (0,0)
+        assertEquals(1, matrix0.tileRange().count());
+        assertTrue(matrix0.contains(TileIndex.of(0, 0, 0)));
+        assertFalse(matrix0.contains(TileIndex.of(1, 0, 0))); // Outside bounds
+
+        // Test coordinate to tile conversion
+        Coordinate center = Coordinate.of(0, 0); // Center of WebMercator
+        Optional<Tile> centerTileOpt = matrix0.coordinateToTile(center);
+        assertTrue(centerTileOpt.isPresent());
+        Tile centerTile = centerTileOpt.get();
+        assertEquals(0, centerTile.x());
+        assertEquals(0, centerTile.y());
+        assertEquals(0, centerTile.z());
+
+        // Test tile extent
+        Extent tileExtent = centerTile.extent();
+        assertNotNull(tileExtent);
+        assertTrue(tileExtent.contains(center));
+    }
+
+    @Test
+    void testTileMatrixSetIntersection() {
+        TileMatrixSet tms = DefaultTileMatrixSets.WEB_MERCATOR_QUAD;
+
+        // Test intersection with Europe extent (roughly)
+        Extent europeExtent = Extent.of(-2000000, 4000000, 4000000, 8000000); // WebMercator coordinates
+        TileMatrixSet intersection = tms.intersection(europeExtent).orElseThrow();
+
+        assertNotNull(intersection);
+        // View-based implementation returns TileMatrixSetView, not TileMatrixSet
+        assertTrue(intersection instanceof TileMatrixSet);
+
+        // Should have same zoom levels but fewer tiles
+        assertEquals(tms.minZoomLevel(), intersection.minZoomLevel());
+        assertEquals(tms.maxZoomLevel(), intersection.maxZoomLevel());
+        assertEquals(tms.crsId(), intersection.crsId());
+        assertEquals(tms.tileWidth(), intersection.tileWidth());
+        assertEquals(tms.tileHeight(), intersection.tileHeight());
+
+        // Check that each zoom level has fewer or equal tiles
+        for (int z = intersection.minZoomLevel(); z <= intersection.maxZoomLevel(); z++) {
+            TileRange originalRange = tms.tilePyramid().tileRange(z);
+            TileRange intersectedRange = intersection.tilePyramid().tileRange(z);
+
+            assertTrue(intersectedRange.count() <= originalRange.count());
+        }
+
+        // Test with non-intersecting extent (well outside WebMercator bounds)
+        Extent noIntersectionExtent = Extent.of(30000000, 30000000, 40000000, 40000000);
+        Optional<TileMatrixSet> emptyIntersection = tms.intersection(noIntersectionExtent);
+        assertThat(emptyIntersection).isEmpty();
+    }
+
+    @Test
+    void testTileMatrixSetIntersectionAtZoomLevel() {
+        TileMatrixSet tms = DefaultTileMatrixSets.WEB_MERCATOR_QUAD;
+
+        // Test intersection with Europe extent at a specific zoom level
+        Extent europeExtent = Extent.of(-2000000, 4000000, 4000000, 8000000); // WebMercator coordinates
+        int targetZoom = 5;
+
+        TileMatrix intersectedMatrix =
+                tms.intersection(europeExtent, targetZoom).orElseThrow();
+
+        assertNotNull(intersectedMatrix);
+        assertEquals(targetZoom, intersectedMatrix.zoomLevel());
+        assertEquals("EPSG:3857", intersectedMatrix.crsId());
+        assertEquals(256, intersectedMatrix.tileWidth());
+        assertEquals(256, intersectedMatrix.tileHeight());
+
+        // Should have fewer tiles than the full matrix at this zoom level
+        TileMatrix fullMatrix = tms.getTileMatrix(targetZoom);
+        assertTrue(
+                intersectedMatrix.tileRange().count() <= fullMatrix.tileRange().count());
+        assertTrue(intersectedMatrix.tileRange().count() > 0); // Should have some tiles
+
+        // Test with non-intersecting extent at specific zoom level
+        Extent noIntersectionExtent = Extent.of(30000000, 30000000, 40000000, 40000000);
+        Optional<TileMatrix> emptyMatrix = tms.intersection(noIntersectionExtent, targetZoom);
+        assertThat(emptyMatrix).isEmpty();
+    }
+
+    @Test
+    void testTileMatrixSetSubset() {
+        TileMatrixSet tms = DefaultTileMatrixSets.WEB_MERCATOR_QUAD;
+
+        // Test zoom subset
+        TileMatrixSet subset = tms.subset(5, 10);
+
+        assertNotNull(subset);
+        assertEquals(5, subset.minZoomLevel());
+        assertEquals(10, subset.maxZoomLevel());
+        assertEquals(6, subset.tilePyramid().levels().size()); // 5-10 inclusive
+        assertEquals("EPSG:3857", subset.crsId());
+        assertEquals(256, subset.tileWidth());
+        assertEquals(256, subset.tileHeight());
+
+        // Should be able to get matrices in range
+        assertTrue(subset.tileMatrix(5).isPresent());
+        assertTrue(subset.tileMatrix(10).isPresent());
+        assertFalse(subset.tileMatrix(4).isPresent()); // Outside range
+        assertFalse(subset.tileMatrix(11).isPresent()); // Outside range
+
+        // Test chaining: subset then intersection
+        Extent europeExtent = Extent.of(-2000000, 4000000, 4000000, 8000000);
+        TileMatrixSet chained = subset.intersection(europeExtent).orElseThrow();
+
+        assertNotNull(chained);
+        assertEquals(5, chained.minZoomLevel());
+        assertEquals(10, chained.maxZoomLevel());
+
+        // Should have fewer tiles than original subset due to spatial filtering
+        for (int z = 5; z <= 10; z++) {
+            long originalCount = subset.getTileMatrix(z).tileRange().count();
+            long filteredCount = chained.getTileMatrix(z).tileRange().count();
+            assertTrue(filteredCount <= originalCount);
+        }
+    }
+}

--- a/src/tileverse-tilepyramid/src/test/java/io/tileverse/tiling/grid/TileMatrixTest.java
+++ b/src/tileverse-tilepyramid/src/test/java/io/tileverse/tiling/grid/TileMatrixTest.java
@@ -1,0 +1,234 @@
+/*
+ * (c) Copyright 2025 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.tiling.grid;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.tileverse.tiling.model.AxisOrigin;
+import io.tileverse.tiling.model.TileIndex;
+import io.tileverse.tiling.model.TileRange;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class TileMatrixTest {
+
+    @Test
+    void testTileMatrixCreation() {
+        TileRange range = TileRange.of(0, 0, 3, 3, 5, AxisOrigin.UPPER_LEFT);
+        TileMatrix matrix = TileMatrix.builder()
+                .tileRange(range)
+                .resolution(156.543)
+                .origin(Coordinate.of(-20037508.34, 20037508.34))
+                .extent(Extent.of(-20037508.34, -20037508.34, 20037508.34, 20037508.34))
+                .crs("EPSG:3857")
+                .tileSize(256, 256)
+                .build();
+
+        assertThat(matrix)
+                .isNotNull()
+                .hasFieldOrPropertyWithValue("zoomLevel", 5)
+                .hasFieldOrPropertyWithValue("resolution", 156.543)
+                .hasFieldOrPropertyWithValue("crsId", "EPSG:3857")
+                .hasFieldOrPropertyWithValue("resolution", 156.543)
+                .hasFieldOrPropertyWithValue("tileWidth", 256)
+                .hasFieldOrPropertyWithValue("tileHeight", 256);
+
+        assertThat(matrix.tileRange()).isEqualTo(range);
+    }
+
+    @Test
+    void testTileExtent() {
+        TileRange range = TileRange.of(0, 0, 1, 1, 0, AxisOrigin.UPPER_LEFT);
+        TileMatrix matrix = TileMatrix.builder()
+                .tileRange(range)
+                .resolution(156543.03)
+                .origin(Coordinate.of(-20037508.34, 20037508.34))
+                .extent(Extent.of(-20037508.34, -20037508.34, 20037508.34, 20037508.34))
+                .crs("EPSG:3857")
+                .tileSize(256, 256)
+                .build();
+
+        Tile tile = matrix.tile(TileIndex.of(0, 0, 0)).orElseThrow();
+        Extent tileExtent = tile.extent();
+
+        assertNotNull(tileExtent);
+        // For UPPER_LEFT origin at zoom 0, tile (0,0) should cover the full world extent
+        // At zoom 0, there's only 1 tile covering the entire world
+        assertEquals(-20037508.34, tileExtent.minX(), 1.0);
+        assertEquals(-20037508.34, tileExtent.minY(), 1.0);
+        assertEquals(20037508.34, tileExtent.maxX(), 1.0);
+        assertEquals(20037508.34, tileExtent.maxY(), 1.0);
+    }
+
+    @Test
+    void testCoordinateToTile() {
+        TileRange range = TileRange.of(0, 0, 1, 1, 0, AxisOrigin.UPPER_LEFT);
+        TileMatrix matrix = TileMatrix.builder()
+                .tileRange(range)
+                .resolution(156543.03)
+                .origin(Coordinate.of(-20037508.34, 20037508.34))
+                .extent(Extent.of(-20037508.34, -20037508.34, 20037508.34, 20037508.34))
+                .crs("EPSG:3857")
+                .tileSize(256, 256)
+                .build();
+
+        // Test coordinate in upper-left quadrant should map to tile (0,0)
+        Coordinate coord = Coordinate.of(-10000000, 10000000);
+        Optional<Tile> tileOpt = matrix.coordinateToTile(coord);
+
+        assertTrue(tileOpt.isPresent());
+        Tile tile = tileOpt.get();
+        assertEquals(0, tile.x());
+        assertEquals(0, tile.y());
+        assertEquals(0, tile.z());
+    }
+
+    @Test
+    void testExtentToRange() {
+        TileRange range = TileRange.of(0, 0, 3, 3, 2, AxisOrigin.UPPER_LEFT);
+        TileMatrix matrix = TileMatrix.builder()
+                .tileRange(range)
+                .resolution(39135.76)
+                .origin(Coordinate.of(-20037508.34, 20037508.34))
+                .extent(Extent.of(-20037508.34, -20037508.34, 20037508.34, 20037508.34))
+                .crs("EPSG:3857")
+                .tileSize(256, 256)
+                .build();
+
+        // Test extent that covers part of the matrix
+        Extent testExtent = Extent.of(-10000000, -10000000, 10000000, 10000000);
+        TileRange resultRange = matrix.extentToRange(testExtent).orElseThrow();
+
+        assertNotNull(resultRange);
+        assertEquals(2, resultRange.zoomLevel());
+        assertTrue(resultRange.count() > 0);
+        assertTrue(range.intersection(resultRange).orElseThrow().count() > 0); // Should intersect with matrix
+    }
+
+    @Test
+    void testContains() {
+        TileRange range = TileRange.of(5, 5, 10, 10, 8, AxisOrigin.UPPER_LEFT);
+        TileMatrix matrix = TileMatrix.builder()
+                .tileRange(range)
+                .resolution(156.543)
+                .origin(Coordinate.of(-20037508.34, 20037508.34))
+                .extent(Extent.of(-20037508.34, -20037508.34, 20037508.34, 20037508.34))
+                .crs("EPSG:3857")
+                .tileSize(256, 256)
+                .build();
+
+        assertTrue(matrix.contains(TileIndex.of(5, 5, 8)));
+        assertTrue(matrix.contains(TileIndex.of(10, 10, 8)));
+        assertTrue(matrix.contains(TileIndex.of(7, 7, 8)));
+
+        assertFalse(matrix.contains(TileIndex.of(4, 5, 8))); // Outside X range
+        assertFalse(matrix.contains(TileIndex.of(5, 4, 8))); // Outside Y range
+        assertFalse(matrix.contains(TileIndex.of(5, 5, 9))); // Wrong zoom level
+    }
+
+    @Test
+    void testWithTileRange() {
+        TileRange originalRange = TileRange.of(0, 0, 10, 10, 5, AxisOrigin.UPPER_LEFT);
+        TileMatrix original = TileMatrix.builder()
+                .tileRange(originalRange)
+                .resolution(156.543)
+                .origin(Coordinate.of(-20037508.34, 20037508.34))
+                .extent(Extent.of(-20037508.34, -20037508.34, 20037508.34, 20037508.34))
+                .crs("EPSG:3857")
+                .tileSize(256, 256)
+                .build();
+
+        TileRange newRange = TileRange.of(2, 2, 8, 8, 5, AxisOrigin.UPPER_LEFT);
+        TileMatrix modified = original.withTileRange(newRange);
+
+        assertEquals(newRange, modified.tileRange());
+        assertEquals(original.resolution(), modified.resolution());
+        assertEquals(original.origin(), modified.origin());
+        assertEquals(original.crsId(), modified.crsId());
+        assertNotEquals(original.extent(), modified.extent()); // Extent should be recalculated
+    }
+
+    @Test
+    void testIntersection() {
+        TileRange range = TileRange.of(0, 0, 7, 7, 3, AxisOrigin.UPPER_LEFT);
+        TileMatrix matrix = TileMatrix.builder()
+                .tileRange(range)
+                .resolution(9783.94) // Zoom level 3
+                .origin(Coordinate.of(-20037508.34, 20037508.34))
+                .extent(Extent.of(-20037508.34, -20037508.34, 20037508.34, 20037508.34))
+                .crs("EPSG:3857")
+                .tileSize(256, 256)
+                .build();
+
+        // Test intersection with a smaller extent
+        Extent smallExtent = Extent.of(-10000000, -10000000, 10000000, 10000000);
+        TileMatrix intersected = matrix.intersection(smallExtent).orElseThrow();
+
+        assertNotNull(intersected);
+        assertEquals(3, intersected.zoomLevel());
+        assertTrue(intersected.tileRange().count() > 0);
+        assertTrue(intersected.tileRange().count() < matrix.tileRange().count());
+
+        // Test intersection with non-intersecting extent
+        Extent noIntersection = Extent.of(30000000, 30000000, 40000000, 40000000);
+        Optional<TileMatrix> empty = matrix.intersection(noIntersection);
+        assertThat(empty).isEmpty();
+
+        // Test full intersection
+        Extent fullExtent = Extent.of(-25000000, -25000000, 25000000, 25000000);
+        TileMatrix full = matrix.intersection(fullExtent).orElseThrow();
+        assertEquals(matrix.tileRange().count(), full.tileRange().count());
+    }
+
+    @Test
+    void testValidation() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            TileMatrix.builder()
+                    .tileRange(null) // Null range
+                    .resolution(156.543)
+                    .origin(Coordinate.of(0, 0))
+                    .extent(Extent.of(0, 0, 1, 1))
+                    .crs("EPSG:3857")
+                    .build();
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            TileMatrix.builder()
+                    .tileRange(TileRange.of(0, 0, 1, 1, 0))
+                    .resolution(0) // Invalid resolution
+                    .origin(Coordinate.of(0, 0))
+                    .extent(Extent.of(0, 0, 1, 1))
+                    .crs("EPSG:3857")
+                    .build();
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            TileMatrix.builder()
+                    .tileRange(TileRange.of(0, 0, 1, 1, 0))
+                    .resolution(156.543)
+                    .origin(Coordinate.of(0, 0))
+                    .extent(Extent.of(0, 0, 1, 1))
+                    .crs("") // Empty CRS
+                    .build();
+        });
+    }
+}

--- a/src/tileverse-tilepyramid/src/test/java/io/tileverse/tiling/model/AxisOriginViewTest.java
+++ b/src/tileverse-tilepyramid/src/test/java/io/tileverse/tiling/model/AxisOriginViewTest.java
@@ -1,0 +1,328 @@
+/*
+ * (c) Copyright 2025 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.tiling.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Comprehensive tests for AxisOriginView coordinate transformations.
+ * Tests all possible axis origin conversions and edge cases.
+ */
+class AxisOriginViewTest {
+
+    @Test
+    void testNoTransformationWhenSameAxisOrigin() {
+        TileRange original = TileRange.of(10, 20, 30, 40, 5, AxisOrigin.LOWER_LEFT);
+        TileRange view = original.withAxisOrigin(AxisOrigin.LOWER_LEFT);
+
+        // Should return the same instance when no transformation needed
+        assertSame(original, view);
+    }
+
+    @Test
+    void testLowerLeftToUpperLeftTransformation() {
+        // Test with zoom level 2 (4x4 grid: coordinates 0-3)
+        TileRange lowerLeft = TileRange.of(1, 1, 2, 2, 2, AxisOrigin.LOWER_LEFT);
+        TileRange upperLeft = lowerLeft.withAxisOrigin(AxisOrigin.UPPER_LEFT);
+
+        // At zoom 2: tiles per side = 2^2 = 4, so max coordinate = 3
+        // Y-flip transformation: newY = (tilesPerSide - 1) - oldY = 3 - oldY
+        // LOWER_LEFT (1,1,2,2) -> UPPER_LEFT (1,1,2,2) with Y coordinates flipped
+        // minY: 3 - 2 = 1, maxY: 3 - 1 = 2
+        assertEquals(1, upperLeft.minx());
+        assertEquals(1, upperLeft.miny()); // 3 - 2 = 1
+        assertEquals(2, upperLeft.maxx());
+        assertEquals(2, upperLeft.maxy()); // 3 - 1 = 2
+        assertEquals(2, upperLeft.zoomLevel());
+        assertEquals(AxisOrigin.UPPER_LEFT, upperLeft.axisOrigin());
+
+        // Verify it's an AxisOriginView
+        assertTrue(upperLeft instanceof AxisOriginView);
+    }
+
+    @Test
+    void testUpperLeftToLowerLeftTransformation() {
+        // Test reverse transformation
+        TileRange upperLeft = TileRange.of(1, 1, 2, 2, 2, AxisOrigin.UPPER_LEFT);
+        TileRange lowerLeft = upperLeft.withAxisOrigin(AxisOrigin.LOWER_LEFT);
+
+        // Same transformation logic applies in reverse
+        assertEquals(1, lowerLeft.minx());
+        assertEquals(1, lowerLeft.miny()); // 3 - 2 = 1
+        assertEquals(2, lowerLeft.maxx());
+        assertEquals(2, lowerLeft.maxy()); // 3 - 1 = 2
+        assertEquals(2, lowerLeft.zoomLevel());
+        assertEquals(AxisOrigin.LOWER_LEFT, lowerLeft.axisOrigin());
+    }
+
+    @Test
+    void testRoundTripTransformation() {
+        TileRange original = TileRange.of(5, 10, 15, 20, 4, AxisOrigin.LOWER_LEFT);
+
+        // Transform to all other axis origins and back
+        TileRange upperLeft = original.withAxisOrigin(AxisOrigin.UPPER_LEFT);
+        TileRange backToLowerLeft = upperLeft.withAxisOrigin(AxisOrigin.LOWER_LEFT);
+
+        // Should have same coordinates after round trip
+        assertEquals(original.minx(), backToLowerLeft.minx());
+        assertEquals(original.miny(), backToLowerLeft.miny());
+        assertEquals(original.maxx(), backToLowerLeft.maxx());
+        assertEquals(original.maxy(), backToLowerLeft.maxy());
+        assertEquals(original.zoomLevel(), backToLowerLeft.zoomLevel());
+        assertEquals(original.axisOrigin(), backToLowerLeft.axisOrigin());
+    }
+
+    @Test
+    void testLeftToRightAxisTransformations() {
+        // Test X-axis flipping transformations
+        TileRange lowerLeft = TileRange.of(1, 1, 2, 2, 2, AxisOrigin.LOWER_LEFT);
+        TileRange lowerRight = lowerLeft.withAxisOrigin(AxisOrigin.LOWER_RIGHT);
+
+        // At zoom 2: tiles per side = 4, so max coordinate = 3
+        // X-flip: newX = (tilesPerSide - 1) - oldX = 3 - oldX
+        // minX: 3 - 2 = 1, maxX: 3 - 1 = 2
+        assertEquals(1, lowerRight.minx()); // 3 - 2 = 1
+        assertEquals(1, lowerRight.miny()); // Y unchanged for LOWER_* -> LOWER_*
+        assertEquals(2, lowerRight.maxx()); // 3 - 1 = 2
+        assertEquals(2, lowerRight.maxy()); // Y unchanged
+        assertEquals(AxisOrigin.LOWER_RIGHT, lowerRight.axisOrigin());
+    }
+
+    @Test
+    void testAllAxisOriginCombinations() {
+        TileRange original = TileRange.of(0, 0, 1, 1, 1, AxisOrigin.LOWER_LEFT);
+
+        // Test transformation to each axis origin
+        AxisOrigin[] origins = AxisOrigin.values();
+        for (AxisOrigin target : origins) {
+            TileRange transformed = original.withAxisOrigin(target);
+            assertEquals(target, transformed.axisOrigin());
+            assertEquals(original.zoomLevel(), transformed.zoomLevel());
+
+            // Verify spans don't change (area is preserved)
+            assertEquals(original.spanX(), transformed.spanX());
+            assertEquals(original.spanY(), transformed.spanY());
+            assertEquals(original.count(), transformed.count());
+        }
+    }
+
+    @Test
+    void testChainedTransformations() {
+        TileRange original = TileRange.of(2, 3, 5, 7, 3, AxisOrigin.LOWER_LEFT);
+
+        // Chain multiple transformations
+        TileRange chained = original.withAxisOrigin(AxisOrigin.UPPER_LEFT)
+                .withAxisOrigin(AxisOrigin.UPPER_RIGHT)
+                .withAxisOrigin(AxisOrigin.LOWER_RIGHT)
+                .withAxisOrigin(AxisOrigin.LOWER_LEFT);
+
+        // Should return to original coordinates
+        assertEquals(original.minx(), chained.minx());
+        assertEquals(original.miny(), chained.miny());
+        assertEquals(original.maxx(), chained.maxx());
+        assertEquals(original.maxy(), chained.maxy());
+        assertEquals(original.zoomLevel(), chained.zoomLevel());
+        assertEquals(original.axisOrigin(), chained.axisOrigin());
+    }
+
+    @Test
+    void testEdgeCaseZeroCoordinates() {
+        // Test with coordinates at origin
+        TileRange origin = TileRange.of(0, 0, 0, 0, 1, AxisOrigin.LOWER_LEFT);
+        TileRange upperLeft = origin.withAxisOrigin(AxisOrigin.UPPER_LEFT);
+
+        // At zoom 1: tiles per side = 2, max coordinate = 1
+        // (0,0) in LOWER_LEFT -> (0,1) in UPPER_LEFT
+        assertEquals(0, upperLeft.minx());
+        assertEquals(1, upperLeft.miny()); // 1 - 0 = 1
+        assertEquals(0, upperLeft.maxx());
+        assertEquals(1, upperLeft.maxy());
+    }
+
+    @Test
+    void testEdgeCaseMaxCoordinates() {
+        // Test with coordinates at maximum for zoom level
+        int zoom = 2;
+        long maxCoord = (1L << zoom) - 1; // 3 for zoom level 2
+
+        TileRange maxRange = TileRange.of(maxCoord, maxCoord, maxCoord, maxCoord, zoom, AxisOrigin.LOWER_LEFT);
+        TileRange upperLeft = maxRange.withAxisOrigin(AxisOrigin.UPPER_LEFT);
+
+        // Max coordinate (3,3) in LOWER_LEFT -> (3,0) in UPPER_LEFT
+        assertEquals(maxCoord, upperLeft.minx());
+        assertEquals(0, upperLeft.miny()); // 3 - 3 = 0
+        assertEquals(maxCoord, upperLeft.maxx());
+        assertEquals(0, upperLeft.maxy());
+    }
+
+    @Test
+    void testHighZoomLevel() {
+        // Test with higher zoom level to ensure no overflow
+        int zoom = 10;
+        TileRange range = TileRange.of(100, 200, 300, 400, zoom, AxisOrigin.LOWER_LEFT);
+        TileRange upperLeft = range.withAxisOrigin(AxisOrigin.UPPER_LEFT);
+
+        long tilesPerSide = 1L << zoom; // 1024 for zoom 10
+        long maxCoord = tilesPerSide - 1; // 1023
+
+        // Verify Y coordinates are flipped correctly
+        assertEquals(100, upperLeft.minx()); // X unchanged
+        assertEquals(maxCoord - 400, upperLeft.miny()); // 1023 - 400 = 623
+        assertEquals(300, upperLeft.maxx()); // X unchanged
+        assertEquals(maxCoord - 200, upperLeft.maxy()); // 1023 - 200 = 823
+    }
+
+    @Test
+    void testSpanAndCountPreservation() {
+        TileRange original = TileRange.of(10, 20, 30, 40, 5, AxisOrigin.LOWER_LEFT);
+
+        for (AxisOrigin target : AxisOrigin.values()) {
+            TileRange transformed = original.withAxisOrigin(target);
+
+            // Spans and counts must be preserved
+            assertEquals(
+                    original.spanX(),
+                    transformed.spanX(),
+                    "X span should be preserved for transformation to " + target);
+            assertEquals(
+                    original.spanY(),
+                    transformed.spanY(),
+                    "Y span should be preserved for transformation to " + target);
+            assertEquals(
+                    original.count(),
+                    transformed.count(),
+                    "Tile count should be preserved for transformation to " + target);
+        }
+    }
+
+    @Test
+    void testMetaTileCountPreservation() {
+        TileRange original = TileRange.of(0, 0, 7, 7, 3, AxisOrigin.LOWER_LEFT);
+
+        for (AxisOrigin target : AxisOrigin.values()) {
+            TileRange transformed = original.withAxisOrigin(target);
+
+            // Meta-tile counts should be preserved
+            assertEquals(
+                    original.countMetaTiles(2, 2),
+                    transformed.countMetaTiles(2, 2),
+                    "2x2 meta-tile count should be preserved for transformation to " + target);
+            assertEquals(
+                    original.countMetaTiles(4, 4),
+                    transformed.countMetaTiles(4, 4),
+                    "4x4 meta-tile count should be preserved for transformation to " + target);
+        }
+    }
+
+    @Test
+    void testCornerMethodsAxisOriginAware() {
+        TileRange lowerLeft = TileRange.of(1, 1, 2, 2, 2, AxisOrigin.LOWER_LEFT);
+        TileRange upperLeft = lowerLeft.withAxisOrigin(AxisOrigin.UPPER_LEFT);
+
+        // Corner methods should return different coordinates based on axis origin
+        assertNotEquals(lowerLeft.lowerLeft(), upperLeft.lowerLeft());
+        assertNotEquals(lowerLeft.upperRight(), upperLeft.upperRight());
+
+        // But should still represent the same logical corners in their respective coordinate systems
+        TileIndex llCorner = upperLeft.lowerLeft();
+        TileIndex urCorner = upperLeft.upperRight();
+
+        // Verify coordinates are within the transformed range
+        assertTrue(llCorner.x() >= upperLeft.minx() && llCorner.x() <= upperLeft.maxx());
+        assertTrue(llCorner.y() >= upperLeft.miny() && llCorner.y() <= upperLeft.maxy());
+        assertTrue(urCorner.x() >= upperLeft.minx() && urCorner.x() <= upperLeft.maxx());
+        assertTrue(urCorner.y() >= upperLeft.miny() && urCorner.y() <= upperLeft.maxy());
+    }
+
+    @Test
+    void testContainsWithTransformedCoordinates() {
+        TileRange lowerLeft = TileRange.of(1, 0, 2, 1, 2, AxisOrigin.LOWER_LEFT);
+        TileRange upperLeft = lowerLeft.withAxisOrigin(AxisOrigin.UPPER_LEFT);
+
+        // At zoom 2: tilesPerSide = 4, maxCoord = 3
+        // LOWER_LEFT (1,0,2,1) -> UPPER_LEFT (1,2,2,3) after Y-flip
+        // minY: 3-1=2, maxY: 3-0=3
+
+        assertEquals(1, upperLeft.minx());
+        assertEquals(2, upperLeft.miny()); // 3 - 1 = 2
+        assertEquals(2, upperLeft.maxx());
+        assertEquals(3, upperLeft.maxy()); // 3 - 0 = 3
+
+        // Test contains with coordinates in the original system
+        TileIndex originalTile = TileIndex.of(1, 0, 2); // Bottom-left tile in LOWER_LEFT
+        assertTrue(lowerLeft.contains(originalTile));
+
+        // Test contains with coordinates in the transformed system
+        TileIndex transformedTile =
+                TileIndex.of(1, 3, 2); // Top-left tile in UPPER_LEFT (corresponds to 1,0 in LOWER_LEFT)
+        assertTrue(upperLeft.contains(transformedTile));
+
+        // Cross-system containment should be false (different coordinate systems)
+        assertFalse(upperLeft.contains(originalTile)); // (1,0) not in UPPER_LEFT range (1,2,2,3)
+        assertFalse(lowerLeft.contains(transformedTile)); // (1,3) not in LOWER_LEFT range (1,0,2,1)
+    }
+
+    @Test
+    void testEqualsAndHashCodeWithAxisOriginView() {
+        TileRange original = TileRange.of(5, 10, 15, 20, 4, AxisOrigin.LOWER_LEFT);
+        TileRange view = original.withAxisOrigin(AxisOrigin.UPPER_LEFT);
+        TileRange backToOriginal = view.withAxisOrigin(AxisOrigin.LOWER_LEFT);
+
+        // Original and round-trip should be equal
+        assertEquals(original, backToOriginal);
+        assertEquals(original.hashCode(), backToOriginal.hashCode());
+
+        // View with different axis origin should not equal original
+        assertNotEquals(original, view);
+        assertNotEquals(original.hashCode(), view.hashCode());
+    }
+
+    @Test
+    void testToStringContainsAxisOriginInfo() {
+        TileRange original = TileRange.of(1, 2, 3, 4, 5, AxisOrigin.LOWER_LEFT);
+        TileRange view = original.withAxisOrigin(AxisOrigin.UPPER_LEFT);
+
+        String viewString = view.toString();
+        assertTrue(viewString.contains("AxisOriginView"), "toString should indicate it's an AxisOriginView");
+        assertTrue(viewString.contains("UPPER_LEFT"), "toString should show target axis origin");
+    }
+
+    @Test
+    void testTraversalMethodsWorkWithAxisOriginView() {
+        TileRange lowerLeft = TileRange.of(0, 0, 1, 1, 1, AxisOrigin.LOWER_LEFT);
+        TileRange upperLeft = lowerLeft.withAxisOrigin(AxisOrigin.UPPER_LEFT);
+
+        // Test that traversal methods work correctly with transformed coordinates
+        TileIndex first = upperLeft.first();
+        TileIndex last = upperLeft.last();
+
+        assertNotNull(first);
+        assertNotNull(last);
+        assertTrue(upperLeft.contains(first));
+        assertTrue(upperLeft.contains(last));
+
+        // Test next/prev work with the view
+        assertTrue(upperLeft.next(first).isPresent());
+        assertTrue(upperLeft.prev(last).isPresent());
+    }
+}

--- a/src/tileverse-tilepyramid/src/test/java/io/tileverse/tiling/model/TileIndexTest.java
+++ b/src/tileverse-tilepyramid/src/test/java/io/tileverse/tiling/model/TileIndexTest.java
@@ -1,0 +1,191 @@
+/*
+ * (c) Copyright 2025 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.tiling.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test class for TileIndex functionality combining 2D and 3D operations.
+ */
+class TileIndexTest {
+
+    @Test
+    void testConstruction3D() {
+        TileIndex index = TileIndex.of(10, 20, 5);
+        assertEquals(10, index.x());
+        assertEquals(20, index.y());
+        assertEquals(5, index.z());
+    }
+
+    @Test
+    void testMemoryOptimization() {
+        // Small coordinates should use TileIndexInt
+        TileIndex smallIndex = TileIndex.of(100, 200, 3);
+        assertTrue(smallIndex instanceof TileIndexInt);
+        assertEquals(100, smallIndex.x());
+        assertEquals(200, smallIndex.y());
+        assertEquals(3, smallIndex.z());
+
+        // Large coordinates should use TileIndexLong
+        TileIndex largeIndex = TileIndex.of(3_000_000_000L, 200, 3);
+        assertTrue(largeIndex instanceof TileIndexLong);
+        assertEquals(3_000_000_000L, largeIndex.x());
+        assertEquals(200, largeIndex.y());
+        assertEquals(3, largeIndex.z());
+
+        // Boundary cases
+        TileIndex maxInt = TileIndex.of(Integer.MAX_VALUE, Integer.MAX_VALUE, 0);
+        assertTrue(maxInt instanceof TileIndexInt);
+
+        TileIndex minInt = TileIndex.of(Integer.MIN_VALUE, Integer.MIN_VALUE, 0);
+        assertTrue(minInt instanceof TileIndexInt);
+
+        TileIndex beyondMaxInt = TileIndex.of((long) Integer.MAX_VALUE + 1, 0, 0);
+        assertTrue(beyondMaxInt instanceof TileIndexLong);
+    }
+
+    @Test
+    void testShiftX() {
+        TileIndex original = TileIndex.of(10, 20, 3);
+        TileIndex shifted = original.shiftX(5);
+
+        assertEquals(15, shifted.x());
+        assertEquals(20, shifted.y());
+        assertEquals(3, shifted.z());
+        // Original should be unchanged
+        assertEquals(10, original.x());
+        assertEquals(20, original.y());
+        assertEquals(3, original.z());
+    }
+
+    @Test
+    void testShiftY() {
+        TileIndex original = TileIndex.of(10, 20, 3);
+        TileIndex shifted = original.shiftY(-5);
+
+        assertEquals(10, shifted.x());
+        assertEquals(15, shifted.y());
+        assertEquals(3, shifted.z());
+    }
+
+    @Test
+    void testShiftBy() {
+        TileIndex original = TileIndex.of(10, 20, 3);
+        TileIndex shifted = original.shiftBy(3, -7);
+
+        assertEquals(13, shifted.x());
+        assertEquals(13, shifted.y());
+        assertEquals(3, shifted.z());
+    }
+
+    @Test
+    void testShiftByFunction() {
+        TileIndex original = TileIndex.of(10, 20, 3);
+        TileIndex shifted = original.shiftBy(x -> x * 2, y -> y / 2);
+
+        assertEquals(20, shifted.x());
+        assertEquals(10, shifted.y());
+        assertEquals(3, shifted.z()); // zoom level unchanged
+    }
+
+    @Test
+    void testAtZoom() {
+        TileIndex original = TileIndex.of(10, 20, 3);
+        TileIndex newZoom = original.atZoom(5);
+
+        assertEquals(10, newZoom.x());
+        assertEquals(20, newZoom.y());
+        assertEquals(5, newZoom.z());
+        // Original unchanged
+        assertEquals(3, original.z());
+    }
+
+    @Test
+    void testCompareTo() {
+        TileIndex index1 = TileIndex.of(5, 10, 1);
+        TileIndex index2 = TileIndex.of(5, 10, 1);
+        TileIndex index3 = TileIndex.of(5, 10, 2); // higher zoom
+        TileIndex index4 = TileIndex.of(5, 15, 1); // same zoom, different Y
+        TileIndex index5 = TileIndex.of(10, 5, 1); // same zoom, different X
+
+        assertEquals(0, index1.compareTo(index2));
+        assertTrue(index1.compareTo(index3) < 0); // lower zoom comes first
+        assertTrue(index3.compareTo(index1) > 0);
+        assertTrue(index1.compareTo(index4) < 0); // same zoom, compare by coordinates
+        assertTrue(index1.compareTo(index5) < 0); // X coordinate comparison
+    }
+
+    @Test
+    void testNegativeCoordinates() {
+        TileIndex index = TileIndex.of(-10, -20, 2);
+        assertEquals(-10, index.x());
+        assertEquals(-20, index.y());
+        assertEquals(2, index.z());
+
+        TileIndex shifted = index.shiftBy(15, 25);
+        assertEquals(5, shifted.x());
+        assertEquals(5, shifted.y());
+        assertEquals(2, shifted.z());
+    }
+
+    @Test
+    void testEqualsAndHashCode() {
+        TileIndex tile1 = TileIndex.of(100, 200, 3);
+        TileIndex tile2 = TileIndex.of(100, 200, 3);
+        TileIndex tile3 = TileIndex.of(100, 200, 4); // different zoom
+        TileIndex tile4 = TileIndex.of(101, 200, 3); // different x
+
+        // Test equals
+        assertEquals(tile1, tile2);
+        assertEquals(tile1, tile1); // reflexive
+        assertNotEquals(tile1, tile3);
+        assertNotEquals(tile1, tile4);
+        assertNotEquals(tile1, null);
+        assertNotEquals(tile1, "not a tile");
+
+        // Test hashCode consistency
+        assertEquals(tile1.hashCode(), tile2.hashCode());
+
+        // Different tiles should ideally have different hash codes (not guaranteed, but likely)
+        assertNotEquals(tile1.hashCode(), tile3.hashCode());
+        assertNotEquals(tile1.hashCode(), tile4.hashCode());
+    }
+
+    @Test
+    void testEqualsAcrossImplementations() {
+        // Create tiles that should be equal but might use different implementations
+        TileIndex smallTile = TileIndex.of(100, 200, 3); // Should use TileIndexInt
+
+        // Force creation of potentially different implementation by using boundary values
+        TileIndex boundaryTile = TileIndex.of(Integer.MAX_VALUE, Integer.MAX_VALUE, 3); // Should use TileIndexInt
+        TileIndex largeTile = TileIndex.of((long) Integer.MAX_VALUE + 1, 200, 3); // Should use TileIndexLong
+
+        // Verify implementation types for our test
+        assertTrue(smallTile instanceof TileIndexInt);
+        assertTrue(boundaryTile instanceof TileIndexInt);
+        assertTrue(largeTile instanceof TileIndexLong);
+
+        // Same coordinates should be equal regardless of implementation
+        TileIndex tile1 = TileIndex.of(50, 60, 2);
+        TileIndex tile2 = TileIndex.of(50, 60, 2);
+        assertEquals(tile1, tile2);
+        assertEquals(tile1.hashCode(), tile2.hashCode());
+    }
+}

--- a/src/tileverse-tilepyramid/src/test/java/io/tileverse/tiling/model/TilePyramidTest.java
+++ b/src/tileverse-tilepyramid/src/test/java/io/tileverse/tiling/model/TilePyramidTest.java
@@ -1,0 +1,220 @@
+/*
+ * (c) Copyright 2025 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.tiling.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test class for TilePyramid functionality.
+ */
+class TilePyramidTest {
+
+    @Test
+    void testEmptyPyramid() {
+        TilePyramid empty = TilePyramid.empty();
+        assertTrue(empty.isEmpty());
+        assertEquals(0, empty.count());
+        assertTrue(empty.levels().isEmpty());
+    }
+
+    @Test
+    void testSingleRangePyramid() {
+        TileRange range = TileRange.of(0, 0, 3, 3, 0);
+        TilePyramid pyramid = TilePyramid.of(range);
+
+        assertFalse(pyramid.isEmpty());
+        assertEquals(16, pyramid.count()); // 4x4 = 16 tiles
+        assertEquals(0, pyramid.minZoomLevel());
+        assertEquals(0, pyramid.maxZoomLevel());
+        assertEquals(1, pyramid.levels().size());
+        assertTrue(pyramid.level(0).isPresent());
+        assertFalse(pyramid.level(1).isPresent());
+    }
+
+    @Test
+    void testMultiLevelPyramid() {
+        SortedSet<TileRange> levels = new TreeSet<>();
+        levels.add(TileRange.of(0, 0, 1, 1, 0)); // zoom 0: 2x2 = 4 tiles
+        levels.add(TileRange.of(0, 0, 3, 3, 1)); // zoom 1: 4x4 = 16 tiles
+        levels.add(TileRange.of(0, 0, 7, 7, 2)); // zoom 2: 8x8 = 64 tiles
+
+        TilePyramid pyramid = TilePyramid.of(levels);
+
+        assertFalse(pyramid.isEmpty());
+        assertEquals(84, pyramid.count()); // 4 + 16 + 64 = 84
+        assertEquals(0, pyramid.minZoomLevel());
+        assertEquals(2, pyramid.maxZoomLevel());
+        assertEquals(3, pyramid.levels().size());
+
+        assertTrue(pyramid.level(0).isPresent());
+        assertTrue(pyramid.level(1).isPresent());
+        assertTrue(pyramid.level(2).isPresent());
+        assertFalse(pyramid.level(3).isPresent());
+    }
+
+    @Test
+    void testLevelsOrder() {
+        List<TileRange> levels = List.of(
+                // Add in reverse order to test sorting
+                TileRange.of(0L, 0L, 7L, 7L, 2), TileRange.of(0L, 0L, 1L, 1L, 0), TileRange.of(0L, 0L, 3L, 3L, 1));
+
+        TilePyramid pyramid = TilePyramid.of(levels);
+
+        List<Integer> actualZoomLevels =
+                pyramid.levels().stream().map(TileRange::zoomLevel).toList();
+
+        assertThat(actualZoomLevels).isEqualTo(List.of(0, 1, 2));
+    }
+
+    @Test
+    void testSubset() {
+        SortedSet<TileRange> levels = new TreeSet<>();
+        IntStream.range(0, 10).forEach(z -> levels.add(TileRange.of(0, 0, (1L << z) - 1, (1L << z) - 1, z)));
+
+        TilePyramid fullPyramid = TilePyramid.of(levels);
+        assertEquals(0, fullPyramid.minZoomLevel());
+        assertEquals(9, fullPyramid.maxZoomLevel());
+
+        // Test fromLevel
+        TilePyramid fromLevel3 = fullPyramid.fromLevel(3);
+        assertEquals(3, fromLevel3.minZoomLevel());
+        assertEquals(9, fromLevel3.maxZoomLevel());
+        assertEquals(7, fromLevel3.levels().size());
+
+        // Test toLevel
+        TilePyramid toLevel6 = fullPyramid.toLevel(6);
+        assertEquals(0, toLevel6.minZoomLevel());
+        assertEquals(6, toLevel6.maxZoomLevel());
+        assertEquals(7, toLevel6.levels().size());
+
+        // Test subset
+        TilePyramid subset = fullPyramid.subset(2, 5);
+        assertEquals(2, subset.minZoomLevel());
+        assertEquals(5, subset.maxZoomLevel());
+        assertEquals(4, subset.levels().size());
+    }
+
+    @Test
+    void testSubsetInvalidArguments() {
+        TilePyramid pyramid = TilePyramid.of(TileRange.of(0, 0, 1, 1, 0));
+
+        assertThrows(IllegalArgumentException.class, () -> pyramid.subset(-1, 0));
+        assertThrows(IllegalArgumentException.class, () -> pyramid.subset(1, 0));
+    }
+
+    @Test
+    void testAsTiles() {
+        List<TileRange> levels = List.of(
+                TileRange.of(0, 0, 1, 1, 0), // 4 tiles
+                TileRange.of(0, 0, 1, 1, 1)); // 4 tiles
+
+        TilePyramid pyramid = TilePyramid.of(levels);
+
+        // Test that asTiles() returns a view with individual tiles
+        TilePyramid asTiles = pyramid.asTiles();
+        assertEquals(pyramid.count(), asTiles.count()); // Same tile count
+        assertEquals(pyramid.levels().size(), asTiles.levels().size()); // Same number of levels
+
+        // For regular TileRange instances, asTiles should return the same ranges
+        for (int i = 0; i < pyramid.levels().size(); i++) {
+            TileRange original = pyramid.levels().get(i);
+            TileRange asTile = asTiles.levels().get(i);
+            assertEquals(original, asTile); // Should be the same for regular TileRange
+        }
+    }
+
+    @Test
+    void testAsMetaTilesAndAsTilesSymmetry() {
+        // Create a pyramid with meta-tiles
+        MetaTileRange metaRange = MetaTileRange.of(0, 0, 2, 2, 1, 3, 3); // 3x3 meta-tiles
+        TilePyramid metaPyramid = TilePyramid.of(metaRange);
+
+        // Convert to individual tiles
+        TilePyramid individualTiles = metaPyramid.asTiles();
+
+        // Convert back to meta-tiles
+        TilePyramid backToMeta = individualTiles.asMetaTiles(3, 3);
+
+        // Should cover the same tile space (though bounds might be slightly different due to alignment)
+        assertEquals(metaPyramid.count(), backToMeta.asTiles().count());
+
+        // Test the symmetric transformation with regular tiles
+        TileRange regularRange = TileRange.of(0, 0, 8, 8, 2); // 9x9 tiles, divisible by 3x3
+        TilePyramid regularPyramid = TilePyramid.of(regularRange);
+
+        TilePyramid asMetaTiles = regularPyramid.asMetaTiles(3, 3);
+        TilePyramid backToTiles = asMetaTiles.asTiles();
+
+        // For perfectly aligned ranges, should be identical
+        assertEquals(regularPyramid.count(), backToTiles.count());
+    }
+
+    @Test
+    void testAsMetaTiles() {
+        TileRange range = TileRange.of(0, 0, 9, 9, 0); // 10x10 = 100 tiles at zoom 0
+        TilePyramid pyramid = TilePyramid.of(range);
+
+        testAsMetaTiles(pyramid, 1, 1);
+        testAsMetaTiles(pyramid, 2, 2);
+        testAsMetaTiles(pyramid, 3, 3);
+        testAsMetaTiles(pyramid, 5, 5);
+
+        IllegalArgumentException ex;
+        ex = assertThrows(IllegalArgumentException.class, () -> pyramid.asMetaTiles(-1, 1));
+        assertThat(ex.getMessage()).contains("width must be > 0");
+
+        ex = assertThrows(IllegalArgumentException.class, () -> pyramid.asMetaTiles(1, -1));
+        assertThat(ex.getMessage()).contains("height must be > 0");
+    }
+
+    private TilePyramid testAsMetaTiles(TilePyramid pyramid, int metaWidth, int metaHeight) {
+        TilePyramid metaTiles = pyramid.asMetaTiles(metaWidth, metaHeight);
+
+        // Check that metaTiles.count() returns the correct number of meta-tiles
+        long metaTileCount = metaTiles.count();
+        long expectedMetaTileCount = pyramid.countMetaTiles(metaWidth, metaHeight);
+        assertEquals(expectedMetaTileCount, metaTileCount);
+
+        // Check that metaTiles.asTiles().count() returns pyramid.count()
+        long tilesFromMetaTiles = metaTiles.asTiles().count();
+        assertEquals(pyramid.count(), tilesFromMetaTiles);
+
+        return metaTiles;
+    }
+
+    @Test
+    void testCountMetaTiles() {
+        TileRange range = TileRange.of(0, 0, 9, 9, 0); // 10x10 = 100 tiles at zoom 0
+        TilePyramid pyramid = TilePyramid.of(range);
+
+        // 10x10 grid with 3x3 meta-tiles should give us 16 meta-tiles
+        // (4x4 grid of meta-tiles to cover the entire 10x10 space)
+        assertEquals(16, pyramid.countMetaTiles(3, 3));
+
+        // 10x10 grid with 5x5 meta-tiles should give us 4 meta-tiles
+        assertEquals(4, pyramid.countMetaTiles(5, 5));
+    }
+}

--- a/src/tileverse-tilepyramid/src/test/java/io/tileverse/tiling/model/TileRangeTest.java
+++ b/src/tileverse-tilepyramid/src/test/java/io/tileverse/tiling/model/TileRangeTest.java
@@ -1,0 +1,777 @@
+/*
+ * (c) Copyright 2025 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.tiling.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test class for TileRange functionality combining 2D and 3D operations.
+ */
+class TileRangeTest {
+
+    @Test
+    void testConstructionFromCoordinates() {
+        TileRange range = TileRange.of(10, 20, 30, 40, 5);
+        assertEquals(5, range.zoomLevel());
+        assertEquals(10, range.minx());
+        assertEquals(20, range.miny());
+        assertEquals(30, range.maxx());
+        assertEquals(40, range.maxy());
+    }
+
+    @Test
+    void testConstructionFromTileIndices() {
+        TileIndex lowerLeft = TileIndex.of(10, 20, 7);
+        TileIndex upperRight = TileIndex.of(30, 40, 7);
+        TileRange range = TileRange.of(lowerLeft, upperRight);
+
+        assertEquals(7, range.zoomLevel());
+        assertEquals(10, range.minx());
+        assertEquals(20, range.miny());
+        assertEquals(30, range.maxx());
+        assertEquals(40, range.maxy());
+        assertEquals(lowerLeft, range.lowerLeft());
+        assertEquals(upperRight, range.upperRight());
+    }
+
+    @Test
+    void testInvalidRange() {
+        // Test invalid ranges where lowerLeft > upperRight
+        assertThrows(IllegalArgumentException.class, () -> TileRange.of(30, 20, 10, 40, 5));
+        assertThrows(IllegalArgumentException.class, () -> TileRange.of(10, 40, 30, 20, 5));
+    }
+
+    @Test
+    void testSpanCalculations() {
+        TileRange range = TileRange.of(0, 0, 9, 9, 2);
+
+        assertEquals(10, range.spanX()); // 0-9 inclusive = 10
+        assertEquals(10, range.spanY()); // 0-9 inclusive = 10
+        assertEquals(100, range.count()); // 10x10 = 100
+    }
+
+    @Test
+    void testMetaTileCounting() {
+        TileRange range = TileRange.of(0, 0, 9, 9, 1); // 10x10 = 100 tiles
+
+        // 10x10 grid with 3x3 meta-tiles should give us 16 meta-tiles
+        // (4x4 grid of meta-tiles to cover the entire 10x10 space)
+        assertEquals(16, range.countMetaTiles(3, 3));
+
+        // 10x10 grid with 5x5 meta-tiles should give us 4 meta-tiles
+        assertEquals(4, range.countMetaTiles(5, 5));
+
+        // Single tile meta-tiles equals total tiles
+        assertEquals(range.count(), range.countMetaTiles(1, 1));
+    }
+
+    @Test
+    void testMetaTileCountingInvalidParameters() {
+        TileRange range = TileRange.of(0, 0, 9, 9, 1);
+
+        assertThrows(IllegalArgumentException.class, () -> range.countMetaTiles(-1, 1));
+        assertThrows(IllegalArgumentException.class, () -> range.countMetaTiles(1, -1));
+        assertThrows(IllegalArgumentException.class, () -> range.countMetaTiles(0, 1));
+        assertThrows(IllegalArgumentException.class, () -> range.countMetaTiles(1, 0));
+    }
+
+    @Test
+    void testTileRangeProperties() {
+        TileRange range = TileRange.of(0, 0, 2, 1, 3); // 3x2 = 6 tiles at zoom 3
+
+        assertEquals(6, range.count());
+        assertEquals(3, range.spanX());
+        assertEquals(2, range.spanY());
+        assertEquals(3, range.zoomLevel());
+
+        // Verify corner coordinates
+        assertEquals(TileIndex.of(0, 0, 3), range.lowerLeft());
+        assertEquals(TileIndex.of(2, 1, 3), range.upperRight());
+    }
+
+    @Test
+    void testMetaTileConversion() {
+        TileRange range = TileRange.of(0, 0, 7, 7, 1); // 8x8 tiles at zoom 1
+
+        // Test meta-tile counting functionality
+        long metaTileCount = range.countMetaTiles(3, 3);
+
+        // 8x8 grid with 3x3 meta-tiles should give us 9 meta-tiles
+        // (3x3 grid of meta-tiles to cover the entire 8x8 space)
+        assertEquals(9, metaTileCount);
+
+        // Verify that meta-tile functionality works correctly
+        assertEquals(4, range.countMetaTiles(4, 4));
+        assertEquals(range.count(), range.countMetaTiles(1, 1));
+    }
+
+    @Test
+    void testMetaTileCountingInvalidParametersAdditional() {
+        TileRange range = TileRange.of(0, 0, 9, 9, 1);
+
+        // Additional validation for countMetaTiles method
+        assertThrows(IllegalArgumentException.class, () -> range.countMetaTiles(-1, 1));
+        assertThrows(IllegalArgumentException.class, () -> range.countMetaTiles(1, -1));
+        assertThrows(IllegalArgumentException.class, () -> range.countMetaTiles(0, 1));
+        assertThrows(IllegalArgumentException.class, () -> range.countMetaTiles(1, 0));
+    }
+
+    @Test
+    void testCompareTo() {
+        TileRange range1 = TileRange.of(0, 0, 5, 5, 1);
+        TileRange range2 = TileRange.of(0, 0, 5, 5, 1);
+        TileRange range3 = TileRange.of(0, 0, 5, 5, 2); // higher zoom
+        TileRange range4 = TileRange.of(1, 0, 5, 5, 1); // same zoom, different bounds
+
+        assertEquals(0, range1.compareTo(range2));
+        assertTrue(range1.compareTo(range3) < 0); // lower zoom comes first
+        assertTrue(range3.compareTo(range1) > 0);
+        assertTrue(range1.compareTo(range4) < 0); // same zoom, compare by bounds
+    }
+
+    @Test
+    void testFactoryMethodConstructor() {
+        TileRange range = TileRange.of(10, 20, 30, 40, 5);
+
+        assertEquals(5, range.zoomLevel());
+        assertEquals(10, range.minx());
+        assertEquals(20, range.miny());
+        assertEquals(30, range.maxx());
+        assertEquals(40, range.maxy());
+        assertEquals(TileIndex.of(10, 20, 5), range.lowerLeft());
+        assertEquals(TileIndex.of(30, 40, 5), range.upperRight());
+    }
+
+    @Test
+    void testSingleTileRange() {
+        TileRange range = TileRange.of(5, 10, 5, 10, 3); // Single tile
+
+        assertEquals(1, range.spanX());
+        assertEquals(1, range.spanY());
+        assertEquals(1, range.count());
+
+        // Verify corner coordinates for single tile
+        assertEquals(TileIndex.of(5, 10, 3), range.lowerLeft());
+        assertEquals(TileIndex.of(5, 10, 3), range.upperRight());
+    }
+
+    @Test
+    void testNegativeCoordinates() {
+        TileRange range = TileRange.of(-10, -20, -5, -15, 2);
+
+        assertEquals(-10, range.minx());
+        assertEquals(-20, range.miny());
+        assertEquals(-5, range.maxx());
+        assertEquals(-15, range.maxy());
+        assertEquals(6, range.spanX()); // -10 to -5 = 6 tiles
+        assertEquals(6, range.spanY()); // -20 to -15 = 6 tiles
+        assertEquals(36, range.count());
+    }
+
+    @Test
+    void testEqualsAndHashCode() {
+        TileRange range1 = TileRange.of(10, 20, 30, 40, 5);
+        TileRange range2 = TileRange.of(10, 20, 30, 40, 5);
+        TileRange range3 = TileRange.of(10, 20, 30, 40, 6); // different zoom
+        TileRange range4 = TileRange.of(11, 20, 30, 40, 5); // different coords
+
+        // Test equality
+        assertEquals(range1, range2);
+        assertNotEquals(range1, range3);
+        assertNotEquals(range1, range4);
+        assertNotEquals(range1, null);
+
+        // Test hash code consistency
+        assertEquals(range1.hashCode(), range2.hashCode());
+
+        // Test static methods
+        assertTrue(TileRange.equals(range1, range2));
+        assertFalse(TileRange.equals(range1, range3));
+        assertFalse(TileRange.equals(range1, null));
+        assertFalse(TileRange.equals(null, range1));
+        assertTrue(TileRange.equals(null, null));
+
+        assertEquals(TileRange.hashCode(range1), TileRange.hashCode(range2));
+        assertEquals(0, TileRange.hashCode(null));
+    }
+
+    @Test
+    void testDifferentImplementationsEquality() {
+        // Create a regular TileRange and a MetaTileRange with same coordinates but different tile sizes
+        TileRange regularRange = TileRange.of(0, 0, 1, 1, 5);
+        MetaTileRange metaRange2x2 = MetaTileRange.of(0, 0, 1, 1, 5, 2, 2);
+        MetaTileRange metaRange1x1 = MetaTileRange.of(0, 0, 1, 1, 5, 1, 1);
+
+        // Regular range and 2x2 meta-tile should NOT be equal (different tile spaces)
+        assertNotEquals(regularRange, metaRange2x2);
+        assertNotEquals(metaRange2x2, regularRange);
+        assertNotEquals(regularRange.hashCode(), metaRange2x2.hashCode());
+        assertFalse(TileRange.equals(regularRange, metaRange2x2));
+
+        // Regular range and 1x1 meta-tile SHOULD be equal (same tile space)
+        assertEquals(regularRange, metaRange1x1);
+        assertEquals(metaRange1x1, regularRange);
+        assertEquals(regularRange.hashCode(), metaRange1x1.hashCode());
+        assertTrue(TileRange.equals(regularRange, metaRange1x1));
+
+        // Two instances of the same type with same coords should be equal
+        MetaTileRange metaRange2x2_copy = MetaTileRange.of(0, 0, 1, 1, 5, 2, 2);
+        assertEquals(metaRange2x2, metaRange2x2_copy);
+        assertEquals(metaRange2x2.hashCode(), metaRange2x2_copy.hashCode());
+
+        // 1x1 and 2x2 meta-tiles with same coords should NOT be equal
+        assertNotEquals(metaRange1x1, metaRange2x2);
+        assertNotEquals(metaRange1x1.hashCode(), metaRange2x2.hashCode());
+        assertFalse(TileRange.equals(metaRange1x1, metaRange2x2));
+
+        // Two 1x1 meta-tiles with same coords should be equal
+        MetaTileRange metaRange1x1_copy = MetaTileRange.of(0, 0, 1, 1, 5, 1, 1);
+        assertEquals(metaRange1x1, metaRange1x1_copy);
+        assertEquals(metaRange1x1.hashCode(), metaRange1x1_copy.hashCode());
+        assertTrue(TileRange.equals(metaRange1x1, metaRange1x1_copy));
+    }
+
+    @Test
+    void testAsMetaTiles() {
+        TileRange range = TileRange.of(0, 0, 7, 7, 5); // 8x8 tiles
+
+        // Convert to 2x2 meta-tiles
+        TileRange metaRange = range.asMetaTiles(2, 2);
+        assertEquals(5, metaRange.zoomLevel());
+        assertEquals(0, metaRange.minx()); // 0/2 = 0
+        assertEquals(0, metaRange.miny()); // 0/2 = 0
+        assertEquals(3, metaRange.maxx()); // 7/2 = 3
+        assertEquals(3, metaRange.maxy()); // 7/2 = 3
+
+        // Verify it's actually a MetaTileRange implementation (implementation detail)
+        assertTrue(metaRange instanceof MetaTileRange);
+        MetaTileRange actualMeta = (MetaTileRange) metaRange;
+        assertEquals(2, actualMeta.tilesWide());
+        assertEquals(2, actualMeta.tilesHigh());
+
+        // Test invalid parameters
+        assertThrows(IllegalArgumentException.class, () -> range.asMetaTiles(-1, 2));
+        assertThrows(IllegalArgumentException.class, () -> range.asMetaTiles(2, -1));
+        assertThrows(IllegalArgumentException.class, () -> range.asMetaTiles(0, 2));
+        assertThrows(IllegalArgumentException.class, () -> range.asMetaTiles(2, 0));
+    }
+
+    @Test
+    void testAsTiles() {
+        // Test regular TileRange - should return itself
+        TileRange regularRange = TileRange.of(5, 10, 15, 20, 3);
+        TileRange asIndividual = regularRange.asTiles();
+        assertEquals(regularRange, asIndividual);
+        assertTrue(regularRange == asIndividual); // Same instance
+
+        // Test MetaTileRange conversion
+        MetaTileRange metaRange = MetaTileRange.of(1, 2, 2, 3, 4, 3, 2);
+        TileRange converted = metaRange.asTiles();
+
+        // Meta-tile (1,2) with 3x2 tiles starts at individual tile (3,4)
+        // Meta-tile (2,3) with 3x2 tiles ends at individual tile (8,7)
+        assertEquals(3, converted.minx()); // 1 * 3 = 3
+        assertEquals(4, converted.miny()); // 2 * 2 = 4
+        assertEquals(8, converted.maxx()); // (2+1) * 3 - 1 = 8
+        assertEquals(7, converted.maxy()); // (3+1) * 2 - 1 = 7
+        assertEquals(4, converted.zoomLevel());
+    }
+
+    @Test
+    void testSymmetricTransformations() {
+        TileRange original = TileRange.of(0, 0, 11, 11, 2); // 12x12 tiles
+
+        // Convert to meta-tiles and back
+        TileRange metaRange = original.asMetaTiles(3, 3);
+        TileRange backToTiles = metaRange.asTiles();
+
+        // Should cover the same or larger area (due to meta-tile boundary alignment)
+        assertTrue(backToTiles.minx() <= original.minx());
+        assertTrue(backToTiles.miny() <= original.miny());
+        assertTrue(backToTiles.maxx() >= original.maxx());
+        assertTrue(backToTiles.maxy() >= original.maxy());
+        assertEquals(original.zoomLevel(), backToTiles.zoomLevel());
+
+        // For perfectly aligned ranges, should be identical
+        TileRange aligned = TileRange.of(0, 0, 8, 8, 2); // 9x9 tiles, divisible by 3x3
+        TileRange alignedMeta = aligned.asMetaTiles(3, 3);
+        TileRange alignedBack = alignedMeta.asTiles();
+        assertEquals(aligned, alignedBack);
+    }
+
+    @Test
+    void testMetaTileIntrospection() {
+        // Regular TileRange
+        TileRange regularRange = TileRange.of(0, 0, 7, 7, 2);
+        assertFalse(regularRange.isMetaTiled());
+        assertEquals(1, regularRange.metaWidth());
+        assertEquals(1, regularRange.metaHeight());
+
+        // MetaTileRange
+        TileRange metaRange = regularRange.asMetaTiles(2, 3);
+        assertTrue(metaRange.isMetaTiled());
+        assertEquals(2, metaRange.metaWidth());
+        assertEquals(3, metaRange.metaHeight());
+
+        // Client can unwrap using asTiles()
+        assertEquals(regularRange, metaRange.asTiles());
+    }
+
+    @Test
+    void testHierarchicalMetaTiling() {
+        // Start with a base tile range
+        TileRange baseTiles = TileRange.of(0, 0, 23, 23, 3); // 24x24 tiles
+
+        // Create first level of meta-tiles (4x4)
+        TileRange level1Meta = baseTiles.asMetaTiles(4, 4);
+        assertTrue(level1Meta.isMetaTiled());
+        assertEquals(4, level1Meta.metaWidth());
+        assertEquals(4, level1Meta.metaHeight());
+        assertEquals(6, level1Meta.spanX()); // 24/4 = 6 meta-tiles
+        assertEquals(6, level1Meta.spanY()); // 24/4 = 6 meta-tiles
+
+        // Create second level of meta-tiles (2x2 individual tiles)
+        TileRange level2Meta = level1Meta.asMetaTiles(2, 2);
+        assertTrue(level2Meta.isMetaTiled());
+        assertEquals(2, level2Meta.metaWidth()); // 2x2 individual tiles
+        assertEquals(2, level2Meta.metaHeight());
+        assertEquals(12, level2Meta.spanX()); // 24/2 = 12 meta-tiles
+        assertEquals(12, level2Meta.spanY()); // 24/2 = 12 meta-tiles
+
+        // Create third level of meta-tiles (3x3 individual tiles)
+        TileRange level3Meta = level2Meta.asMetaTiles(3, 3);
+        assertTrue(level3Meta.isMetaTiled());
+        assertEquals(3, level3Meta.metaWidth());
+        assertEquals(3, level3Meta.metaHeight());
+        assertEquals(8, level3Meta.spanX()); // 24/3 = 8 meta-tiles
+        assertEquals(8, level3Meta.spanY()); // 24/3 = 8 meta-tiles
+
+        // Verify asTiles() works at all levels (gets back to base level)
+        assertEquals(baseTiles, level1Meta.asTiles());
+        assertEquals(baseTiles, level2Meta.asTiles());
+        assertEquals(baseTiles, level3Meta.asTiles());
+
+        // All views share the same source - they are different interpretations of the same base
+        assertTrue(level1Meta instanceof MetaTileRange);
+        assertTrue(level2Meta instanceof MetaTileRange);
+        assertTrue(level3Meta instanceof MetaTileRange);
+        assertEquals(baseTiles, ((MetaTileRange) level1Meta).getSource());
+        assertEquals(baseTiles, ((MetaTileRange) level2Meta).getSource());
+        assertEquals(baseTiles, ((MetaTileRange) level3Meta).getSource());
+    }
+
+    @Test
+    void testSuperTiledPyramid() {
+        // Create a pyramid and apply multiple levels of meta-tiling
+        TileRange baseRange = TileRange.of(0, 0, 31, 31, 5); // 32x32 = 1024 base tiles
+        TilePyramid basePyramid = TilePyramid.of(baseRange);
+
+        // Create multiple levels of meta-tile views
+        TilePyramid meta2x2 = basePyramid.asMetaTiles(2, 2); // 16x16 meta-tiles
+        TilePyramid meta4x4 = meta2x2.asMetaTiles(2, 2); // 8x8 super-meta-tiles
+        TilePyramid meta8x8 = meta4x4.asMetaTiles(2, 2); // 4x4 super-super-meta-tiles
+
+        // Verify tile counts are preserved
+        assertEquals(basePyramid.count(), meta2x2.asTiles().count());
+        assertEquals(basePyramid.count(), meta4x4.asTiles().count());
+        assertEquals(basePyramid.count(), meta8x8.asTiles().count());
+
+        // Verify meta-tile counts (each view creates different meta-tile dimensions)
+        assertEquals(256, meta2x2.count()); // 32/2=16, so 16x16 = 256 meta-tiles
+        assertEquals(256, meta4x4.count()); // Still 2x2 meta-tiles of base, so 16x16 = 256
+        assertEquals(256, meta8x8.count()); // Still 2x2 meta-tiles of base, so 16x16 = 256
+
+        // Verify client can inspect and unwrap meta-tile properties
+        TileRange level0Range = meta8x8.levels().get(0);
+        assertTrue(level0Range.isMetaTiled());
+        assertEquals(2, level0Range.metaWidth());
+        assertEquals(2, level0Range.metaHeight());
+        assertEquals(basePyramid.levels().get(0), level0Range.asTiles());
+    }
+
+    @Test
+    void testSubsetViewPreservesZoomLevelsAfterAsTiles() {
+        // Create a multi-level pyramid
+        List<TileRange> levels = List.of(
+                TileRange.of(0, 0, 7, 7, 0), // zoom 0: 8x8 = 64 tiles
+                TileRange.of(0, 0, 15, 15, 1), // zoom 1: 16x16 = 256 tiles
+                TileRange.of(0, 0, 31, 31, 2), // zoom 2: 32x32 = 1024 tiles
+                TileRange.of(0, 0, 63, 63, 3), // zoom 3: 64x64 = 4096 tiles
+                TileRange.of(0, 0, 127, 127, 4) // zoom 4: 128x128 = 16384 tiles
+                );
+        TilePyramid fullPyramid = TilePyramid.of(levels);
+
+        // Create a meta-tile view
+        TilePyramid metaPyramid = fullPyramid.asMetaTiles(4, 4);
+
+        // Create a subset of the meta-tile pyramid (levels 1-3)
+        TilePyramid metaSubset = metaPyramid.subset(1, 3);
+        assertEquals(3, metaSubset.levels().size()); // Should have 3 levels
+        assertEquals(1, metaSubset.minZoomLevel());
+        assertEquals(3, metaSubset.maxZoomLevel());
+
+        // Convert subset back to individual tiles - should preserve zoom level bounds
+        TilePyramid tilesSubset = metaSubset.asTiles();
+        assertEquals(3, tilesSubset.levels().size()); // Should still have 3 levels
+        assertEquals(1, tilesSubset.minZoomLevel()); // Should still start at level 1
+        assertEquals(3, tilesSubset.maxZoomLevel()); // Should still end at level 3
+
+        // Verify the tile counts match the original levels 1-3
+        TilePyramid originalSubset = fullPyramid.subset(1, 3);
+        assertEquals(originalSubset.count(), tilesSubset.count());
+
+        // Verify each level matches
+        for (int z = 1; z <= 3; z++) {
+            TileRange originalLevel = originalSubset.level(z).orElseThrow();
+            TileRange tilesLevel = tilesSubset.level(z).orElseThrow();
+            assertEquals(originalLevel, tilesLevel);
+        }
+
+        // Verify levels 0 and 4 are not present
+        assertTrue(tilesSubset.level(0).isEmpty());
+        assertTrue(tilesSubset.level(4).isEmpty());
+    }
+
+    @Test
+    void testAxisOriginDefault() {
+        // Default axis origin should be LOWER_LEFT
+        TileRange range = TileRange.of(0, 0, 3, 3, 2);
+        assertEquals(AxisOrigin.LOWER_LEFT, range.axisOrigin());
+    }
+
+    @Test
+    void testAxisOriginExplicit() {
+        // Explicit axis origin
+        TileRange range = TileRange.of(0, 0, 3, 3, 2, AxisOrigin.UPPER_LEFT);
+        assertEquals(AxisOrigin.UPPER_LEFT, range.axisOrigin());
+    }
+
+    @Test
+    void testAxisOriginTransformation() {
+        // Create a 4x4 tile range at zoom level 2 (2^2 = 4 tiles per side)
+        TileRange lowerLeftRange = TileRange.of(0, 0, 3, 3, 2, AxisOrigin.LOWER_LEFT);
+
+        // Convert to upper-left origin
+        TileRange upperLeftRange = lowerLeftRange.withAxisOrigin(AxisOrigin.UPPER_LEFT);
+
+        // In a 4x4 grid (zoom 2), coordinates should flip:
+        // LOWER_LEFT (0,0) -> UPPER_LEFT (0,3)
+        // LOWER_LEFT (3,3) -> UPPER_LEFT (3,0)
+        assertEquals(AxisOrigin.UPPER_LEFT, upperLeftRange.axisOrigin());
+        assertEquals(0, upperLeftRange.minx()); // X doesn't change
+        assertEquals(0, upperLeftRange.miny()); // (2^2-1) - 3 = 0
+        assertEquals(3, upperLeftRange.maxx()); // X doesn't change
+        assertEquals(3, upperLeftRange.maxy()); // (2^2-1) - 0 = 3
+
+        // Convert back should restore original coordinates
+        TileRange backToLowerLeft = upperLeftRange.withAxisOrigin(AxisOrigin.LOWER_LEFT);
+        assertEquals(lowerLeftRange.minx(), backToLowerLeft.minx());
+        assertEquals(lowerLeftRange.miny(), backToLowerLeft.miny());
+        assertEquals(lowerLeftRange.maxx(), backToLowerLeft.maxx());
+        assertEquals(lowerLeftRange.maxy(), backToLowerLeft.maxy());
+        assertEquals(AxisOrigin.LOWER_LEFT, backToLowerLeft.axisOrigin());
+    }
+
+    @Test
+    void testAxisOriginNoTransformation() {
+        // Converting to same origin should return same instance
+        TileRange range = TileRange.of(0, 0, 3, 3, 2, AxisOrigin.LOWER_LEFT);
+        TileRange sameOrigin = range.withAxisOrigin(AxisOrigin.LOWER_LEFT);
+
+        assertTrue(range == sameOrigin); // Same instance
+    }
+
+    @Test
+    void testTilePyramidAxisConsistency() {
+        // Create ranges with different axis origins
+        TileRange lowerLeftRange = TileRange.of(0, 0, 1, 1, 0, AxisOrigin.LOWER_LEFT);
+        TileRange upperLeftRange = TileRange.of(0, 0, 1, 1, 1, AxisOrigin.UPPER_LEFT);
+
+        // Builder should convert all ranges to pyramid's axis origin
+        TilePyramid pyramid = TilePyramid.builder()
+                .axisOrigin(AxisOrigin.UPPER_LEFT)
+                .level(lowerLeftRange)
+                .level(upperLeftRange)
+                .build();
+
+        // All levels should have UPPER_LEFT axis origin
+        assertEquals(AxisOrigin.UPPER_LEFT, pyramid.axisOrigin());
+        for (TileRange level : pyramid.levels()) {
+            assertEquals(AxisOrigin.UPPER_LEFT, level.axisOrigin());
+        }
+    }
+
+    @Test
+    void testCornerMethodsLowerLeft() {
+        // Test all four corner methods with LOWER_LEFT axis origin (default)
+        TileRange range = TileRange.of(10, 20, 30, 40, 5, AxisOrigin.LOWER_LEFT);
+
+        // Lower-left corner (minx, miny) for LOWER_LEFT
+        TileIndex lowerLeft = range.lowerLeft();
+        assertEquals(10, lowerLeft.x());
+        assertEquals(20, lowerLeft.y());
+        assertEquals(5, lowerLeft.z());
+
+        // Upper-right corner (maxx, maxy) for LOWER_LEFT
+        TileIndex upperRight = range.upperRight();
+        assertEquals(30, upperRight.x());
+        assertEquals(40, upperRight.y());
+        assertEquals(5, upperRight.z());
+
+        // Lower-right corner (maxx, miny) for LOWER_LEFT
+        TileIndex lowerRight = range.lowerRight();
+        assertEquals(30, lowerRight.x());
+        assertEquals(20, lowerRight.y());
+        assertEquals(5, lowerRight.z());
+
+        // Upper-left corner (minx, maxy) for LOWER_LEFT
+        TileIndex upperLeft = range.upperLeft();
+        assertEquals(10, upperLeft.x());
+        assertEquals(40, upperLeft.y());
+        assertEquals(5, upperLeft.z());
+    }
+
+    @Test
+    void testCornerMethodsUpperLeft() {
+        // Test corner methods with UPPER_LEFT axis origin (like PMTiles)
+        TileRange range = TileRange.of(10, 20, 30, 40, 5, AxisOrigin.UPPER_LEFT);
+
+        // Lower-left corner: In UPPER_LEFT, "lower" means higher Y values
+        // So lower-left = (minx, maxy)
+        TileIndex lowerLeft = range.lowerLeft();
+        assertEquals(10, lowerLeft.x());
+        assertEquals(40, lowerLeft.y()); // maxy for UPPER_LEFT
+        assertEquals(5, lowerLeft.z());
+
+        // Upper-right corner: In UPPER_LEFT, "upper" means lower Y values
+        // So upper-right = (maxx, miny)
+        TileIndex upperRight = range.upperRight();
+        assertEquals(30, upperRight.x());
+        assertEquals(20, upperRight.y()); // miny for UPPER_LEFT
+        assertEquals(5, upperRight.z());
+
+        // Lower-right corner: (maxx, maxy) for UPPER_LEFT
+        TileIndex lowerRight = range.lowerRight();
+        assertEquals(30, lowerRight.x());
+        assertEquals(40, lowerRight.y()); // maxy for UPPER_LEFT
+        assertEquals(5, lowerRight.z());
+
+        // Upper-left corner: (minx, miny) for UPPER_LEFT
+        TileIndex upperLeft = range.upperLeft();
+        assertEquals(10, upperLeft.x());
+        assertEquals(20, upperLeft.y()); // miny for UPPER_LEFT
+        assertEquals(5, upperLeft.z());
+    }
+
+    @Test
+    void testFirstLastMethods() {
+        // Test first() and last() methods for traversal
+        TileRange lowerLeftRange = TileRange.of(10, 20, 30, 40, 5, AxisOrigin.LOWER_LEFT);
+        TileRange upperLeftRange = TileRange.of(10, 20, 30, 40, 5, AxisOrigin.UPPER_LEFT);
+
+        // first() should equal lowerLeft() for both axis origins
+        assertEquals(lowerLeftRange.lowerLeft(), lowerLeftRange.first());
+        assertEquals(upperLeftRange.lowerLeft(), upperLeftRange.first());
+
+        // last() should equal upperRight() for both axis origins
+        assertEquals(lowerLeftRange.upperRight(), lowerLeftRange.last());
+        assertEquals(upperLeftRange.upperRight(), upperLeftRange.last());
+
+        // Verify the actual coordinates for LOWER_LEFT
+        TileIndex lowerLeftFirst = lowerLeftRange.first();
+        assertEquals(10, lowerLeftFirst.x()); // minx, miny
+        assertEquals(20, lowerLeftFirst.y());
+
+        TileIndex lowerLeftLast = lowerLeftRange.last();
+        assertEquals(30, lowerLeftLast.x()); // maxx, maxy
+        assertEquals(40, lowerLeftLast.y());
+
+        // Verify the actual coordinates for UPPER_LEFT
+        TileIndex upperLeftFirst = upperLeftRange.first();
+        assertEquals(10, upperLeftFirst.x()); // minx, maxy (visual lower-left)
+        assertEquals(40, upperLeftFirst.y());
+
+        TileIndex upperLeftLast = upperLeftRange.last();
+        assertEquals(30, upperLeftLast.x()); // maxx, miny (visual upper-right)
+        assertEquals(20, upperLeftLast.y());
+    }
+
+    @Test
+    void testNextPrevMethods() {
+        // Test with a small 2x2 range for easy verification
+        TileRange range = TileRange.of(10, 20, 11, 21, 5, AxisOrigin.LOWER_LEFT);
+
+        // Expected traversal order for LOWER_LEFT (left-to-right, bottom-to-top):
+        // (10,20) -> (11,20) -> (10,21) -> (11,21)
+
+        TileIndex first = range.first(); // (10,20)
+        assertEquals(10, first.x());
+        assertEquals(20, first.y());
+
+        // Test next() progression
+        Optional<TileIndex> next1 = range.next(first);
+        assertTrue(next1.isPresent());
+        assertEquals(11, next1.get().x()); // (11,20)
+        assertEquals(20, next1.get().y());
+
+        Optional<TileIndex> next2 = range.next(next1.get());
+        assertTrue(next2.isPresent());
+        assertEquals(10, next2.get().x()); // (10,21) - wrap to next row
+        assertEquals(21, next2.get().y());
+
+        Optional<TileIndex> next3 = range.next(next2.get());
+        assertTrue(next3.isPresent());
+        assertEquals(11, next3.get().x()); // (11,21)
+        assertEquals(21, next3.get().y());
+
+        // Should be the last tile
+        assertEquals(range.last(), next3.get());
+
+        // Next from last should be empty
+        Optional<TileIndex> next4 = range.next(next3.get());
+        assertTrue(next4.isEmpty());
+
+        // Test prev() progression (reverse)
+        Optional<TileIndex> prev1 = range.prev(next3.get());
+        assertTrue(prev1.isPresent());
+        assertEquals(next2.get(), prev1.get()); // (10,21)
+
+        Optional<TileIndex> prev2 = range.prev(prev1.get());
+        assertTrue(prev2.isPresent());
+        assertEquals(next1.get(), prev2.get()); // (11,20)
+
+        Optional<TileIndex> prev3 = range.prev(prev2.get());
+        assertTrue(prev3.isPresent());
+        assertEquals(first, prev3.get()); // (10,20)
+
+        // Prev from first should be empty
+        Optional<TileIndex> prev4 = range.prev(prev3.get());
+        assertTrue(prev4.isEmpty());
+    }
+
+    @Test
+    void testNextPrevUpperLeft() {
+        // Test with UPPER_LEFT axis origin (like PMTiles)
+        TileRange range = TileRange.of(10, 20, 11, 21, 5, AxisOrigin.UPPER_LEFT);
+
+        // Expected traversal order for UPPER_LEFT (left-to-right, top-to-bottom):
+        // Note: first() = lowerLeft() = (10,21) for UPPER_LEFT
+        // last() = upperRight() = (11,20) for UPPER_LEFT
+        // Traversal: (10,21) -> (11,21) -> (10,20) -> (11,20)
+
+        TileIndex first = range.first(); // lowerLeft in UPPER_LEFT = (10,21)
+        assertEquals(10, first.x());
+        assertEquals(21, first.y());
+
+        // Test complete traversal
+        Optional<TileIndex> next1 = range.next(first);
+        assertTrue(next1.isPresent());
+        assertEquals(11, next1.get().x()); // (11,21)
+        assertEquals(21, next1.get().y());
+
+        Optional<TileIndex> next2 = range.next(next1.get());
+        assertTrue(next2.isPresent());
+        assertEquals(10, next2.get().x()); // (10,20) - wrap to next row
+        assertEquals(20, next2.get().y());
+
+        Optional<TileIndex> next3 = range.next(next2.get());
+        assertTrue(next3.isPresent());
+        assertEquals(11, next3.get().x()); // (11,20)
+        assertEquals(20, next3.get().y());
+
+        // Should be the last tile
+        assertEquals(range.last(), next3.get());
+
+        // Next from last should be empty
+        assertTrue(range.next(next3.get()).isEmpty());
+    }
+
+    @Test
+    void testNextPrevEdgeCases() {
+        TileRange range = TileRange.of(10, 20, 11, 21, 5, AxisOrigin.LOWER_LEFT);
+
+        // Test with null
+        assertTrue(range.next(null).isEmpty());
+        assertTrue(range.prev(null).isEmpty());
+
+        // Test with wrong zoom level
+        TileIndex wrongZoom = TileIndex.of(10, 20, 6);
+        assertTrue(range.next(wrongZoom).isEmpty());
+        assertTrue(range.prev(wrongZoom).isEmpty());
+
+        // Test with tile outside range
+        TileIndex outsideRange = TileIndex.of(5, 20, 5);
+        assertTrue(range.next(outsideRange).isEmpty());
+        assertTrue(range.prev(outsideRange).isEmpty());
+
+        // Test with tile outside Y range
+        TileIndex outsideY = TileIndex.of(10, 25, 5);
+        assertTrue(range.next(outsideY).isEmpty());
+        assertTrue(range.prev(outsideY).isEmpty());
+    }
+
+    @Test
+    void testIntersection() {
+        // Test overlapping ranges
+        TileRange range1 = TileRange.of(5, 10, 15, 20, 8, AxisOrigin.UPPER_LEFT);
+        TileRange range2 = TileRange.of(10, 15, 25, 30, 8, AxisOrigin.UPPER_LEFT);
+
+        TileRange intersection = range1.intersection(range2).orElseThrow();
+
+        assertEquals(8, intersection.zoomLevel());
+        assertEquals(10, intersection.minx()); // max(5, 10)
+        assertEquals(15, intersection.miny()); // max(10, 15)
+        assertEquals(15, intersection.maxx()); // min(15, 25)
+        assertEquals(20, intersection.maxy()); // min(20, 30)
+        assertEquals(AxisOrigin.UPPER_LEFT, intersection.axisOrigin());
+
+        // Test non-overlapping ranges
+        TileRange range3 = TileRange.of(0, 0, 5, 5, 8, AxisOrigin.UPPER_LEFT);
+        TileRange range4 = TileRange.of(10, 10, 15, 15, 8, AxisOrigin.UPPER_LEFT);
+
+        assertThat(range3.intersection(range4)).isEmpty();
+
+        // Test identical ranges
+        TileRange range5 = TileRange.of(10, 20, 30, 40, 5, AxisOrigin.LOWER_LEFT);
+        TileRange identicalIntersection = range5.intersection(range5).orElseThrow();
+        assertEquals(range5.minx(), identicalIntersection.minx());
+        assertEquals(range5.miny(), identicalIntersection.miny());
+        assertEquals(range5.maxx(), identicalIntersection.maxx());
+        assertEquals(range5.maxy(), identicalIntersection.maxy());
+
+        // Test null intersection
+        assertThrows(NullPointerException.class, () -> range5.intersection(null));
+    }
+
+    @Test
+    void testIntersectionDifferentZoomLevels() {
+        TileRange range1 = TileRange.of(0, 0, 10, 10, 5, AxisOrigin.UPPER_LEFT);
+        TileRange range2 = TileRange.of(5, 5, 15, 15, 6, AxisOrigin.UPPER_LEFT); // Different zoom level
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            range1.intersection(range2);
+        });
+    }
+}


### PR DESCRIPTION
This module provides a complete tiling infrastructure with clear separation of concerns between discrete tile grids and coordinate reference systems.

`TilePyramid` handles the discrete tile grid structure and zoom level management, remaining CRS-agnostic and focused purely on tile indexing. `TileMatrixSet` bridges this discrete grid to real-world coordinates, handling the spatial transformation between tile space and map space through resolutions and origins.

`StandardTileMatrixSet` provides the core implementation with direct array indexing for performance, while `TileMatrixSetView` enables efficient filtering through zoom and spatial subsetting without data copying.

`TileMatrix` objects represent spatial-aware tile collections at specific zoom levels, supporting intersection operations and coordinate transformations.

Individual `Tile` objects combine tile indices with their spatial properties.

`TileRange` handles rectangular tile ranges with spatial extent calculations.

The architecture maintains strict separation between spatial and non-spatial concerns, supports thread-safe server usage, and includes PMTiles-compatible indexing schemes. DefaultTileMatrixSets provides common configurations for EPSG:4326, EPSG:3857, and OGC standards.